### PR TITLE
ci: add test-skills workflow (migrated from notte-cli)

### DIFF
--- a/.github/workflows/test-skills.yml
+++ b/.github/workflows/test-skills.yml
@@ -1,0 +1,29 @@
+name: Test Skills
+
+on:
+  push:
+    paths:
+      - 'plugins/**/templates/**'
+  pull_request:
+    paths:
+      - 'plugins/**/templates/**'
+
+jobs:
+  lint-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate shell scripts syntax
+        run: |
+          shopt -s globstar nullglob
+          for script in plugins/**/templates/*.sh; do
+            echo "Checking syntax: $script"
+            bash -n "$script"
+          done
+
+      - name: Lint with shellcheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: './plugins'
+          severity: warning


### PR DESCRIPTION
## Summary
- Migrates the `test-skills` workflow from [`notte-cli`](https://github.com/nottelabs/notte-cli) (removed in nottelabs/notte-cli#37) to this repo, where the skill sources now live
- Generalised paths from `skills/notte-browser/templates/**` to `plugins/**/templates/**` so future plugins (e.g. `notte-sdks`) are auto-covered
- Validates shell-script syntax via `bash -n` and lints with `shellcheck` at warning severity

## Test plan
- [ ] CI runs on this PR and passes
- [ ] Workflow triggers on changes under `plugins/**/templates/**`