### PR TITLE
Document only-main-content scrape tradeoff

### DIFF
--- a/plugins/notte-cli/skills/notte-browser/SKILL.md
+++ b/plugins/notte-cli/skills/notte-browser/SKILL.md
@@ -209,6 +209,13 @@ notte page screenshot
 notte page scrape --instructions "Extract all links" [--only-main-content]
 ```
 
+`--only-main-content` can reduce output size and token cost by filtering out
+navigation, sidebars, footers, and other page chrome. It can also reduce recall,
+especially on dynamic pages or layouts where important content is not classified
+as main content. When completeness matters, try scraping without
+`--only-main-content` first, then add it only if the full-page output is too
+noisy or expensive.
+
 **Utilities:**
 ```bash
 # Wait for specified duration


### PR DESCRIPTION
## Summary
- document that `--only-main-content` can reduce scrape output size and token cost
- note that it may lower recall on dynamic or nonstandard pages
- recommend trying a full-page scrape first when completeness matters

## Testing
- docs-only change; not run