### PR TITLE
docs: thread --session-id explicitly in scripts and parallel workers

### DIFF
--- a/plugins/notte-cli/skills/notte-browser/SKILL.md
+++ b/plugins/notte-cli/skills/notte-browser/SKILL.md
@@ -117,7 +117,9 @@ notte sessions stop
 notte sessions list [--page N] [--page-size N] [--only-active]
 ```
 
-**Note:** When you start a session, it automatically becomes the "current" session (i.e NOTTE_SESSION_ID environment variable is set). All subsequent commands use this session by default. Use `--session-id <session-id>` only when you need to manage multiple sessions simultaneously or reference a specific session.
+**Note (interactive terminal):** When you start a session from an interactive shell, it automatically becomes the "current" session (recorded in `~/.notte/cli/current_session`) and subsequent commands pick it up by default. Use `--session-id <session-id>` only when you need to manage multiple sessions simultaneously or reference a specific session.
+
+**Note (scripts, subagents, CI, parallel workers):** In non-interactive contexts the CLI does **not** write `~/.notte/cli/current_session`. This is intentional - the file is a single shared slot, so writing it from parallel workers caused sibling processes to read each other's IDs and stop each other's sessions. **You must capture the session ID from `sessions start` output and thread it explicitly** via `--session-id` or `NOTTE_SESSION_ID` on every follow-up call. See [Scripted and parallel use](#scripted-and-parallel-use) below.
 
 Session debugging and export:
 
@@ -282,7 +284,7 @@ notte agents workflow-code
 notte agents replay
 ```
 
-**Note:** When you start an agent, it automatically becomes the "current" agent (saved to `~/.notte/cli/current_agent`). All subsequent commands use this agent by default. Use `--agent-id <agent-id>` only when you need to manage multiple agents simultaneously or reference a specific agent.
+**Note:** In an interactive terminal, starting an agent makes it the "current" agent (saved to `~/.notte/cli/current_agent`) and follow-up commands pick it up by default. **In non-interactive contexts the CLI does not write that file** (same race-avoidance reason as sessions). Scripted callers must capture the agent ID from the start response and thread it explicitly via `--agent-id` or `NOTTE_AGENT_ID`. Use `--agent-id <agent-id>` interactively only when you need to manage multiple agents simultaneously or reference a specific one.
 
 **Agent ID Resolution:**
 1. `--agent-id` flag (highest priority)
@@ -421,7 +423,62 @@ Available on all commands:
 Session ID is resolved in this order:
 1. `--session-id` flag
 2. `NOTTE_SESSION_ID` environment variable
-3. Current session file (set automatically by `sessions start`)
+3. `~/.notte/cli/current_session` file (written automatically by `sessions start` **only in interactive terminals** - scripts and subagents must use option 1 or 2)
+
+## Scripted and parallel use
+
+The `~/.notte/cli/current_session` file is a single shared slot. If two scripts run `notte sessions start` in parallel without isolating their session IDs, they race to overwrite that file and end up stopping each other's sessions on the next `sessions start`. To prevent that footgun, the CLI does not write the file when stdin is not a terminal.
+
+In scripts, subagents, CI, and parallel workers, always capture the session ID from the start output and pass it explicitly. JSON output makes this trivial:
+
+```bash
+SESSION_ID=$(notte sessions start --headless -o json | jq -r '.session_id')
+
+notte page goto "https://example.com" --session-id "$SESSION_ID"
+notte page observe --session-id "$SESSION_ID"
+notte page scrape --instructions "Extract titles" --session-id "$SESSION_ID"
+notte sessions stop --session-id "$SESSION_ID" --yes
+```
+
+Or, if you want to avoid passing `--session-id` on every line, export it:
+
+```bash
+export NOTTE_SESSION_ID=$(notte sessions start --headless -o json | jq -r '.session_id')
+
+notte page goto "https://example.com"
+notte page observe
+notte sessions stop --yes
+unset NOTTE_SESSION_ID
+```
+
+**Cleanup pattern** - sessions consume resources, so always stop them. The trap below works even if your script errors out partway through:
+
+```bash
+set -euo pipefail
+SESSION_ID=$(notte sessions start --headless -o json | jq -r '.session_id')
+trap 'notte sessions stop --session-id "$SESSION_ID" --yes 2>/dev/null || true' EXIT
+
+# ... rest of your script using --session-id "$SESSION_ID" ...
+```
+
+**Parallel workers** - each worker manages its own session ID. Never share a session ID across workers (the underlying browser session is single-tenant), and never rely on the current-session file to communicate between them.
+
+```bash
+run_one_worker() {
+  SESSION_ID=$(notte sessions start --headless -o json | jq -r '.session_id')
+  trap 'notte sessions stop --session-id "$SESSION_ID" --yes 2>/dev/null || true' EXIT
+
+  notte page goto "$1" --session-id "$SESSION_ID"
+  notte page scrape --instructions "Extract main content" --session-id "$SESSION_ID"
+}
+
+for url in "$@"; do
+  run_one_worker "$url" &
+done
+wait
+```
+
+The same contract applies to agents: capture `agent_id` from `notte agents start -o json` and pass `--agent-id` (or set `NOTTE_AGENT_ID`) on every follow-up call.
 
 ## Examples
 

--- a/plugins/notte-cli/skills/notte-browser/references/session-management.md
+++ b/plugins/notte-cli/skills/notte-browser/references/session-management.md
@@ -67,9 +67,9 @@ notte sessions start --cdp-url "ws://localhost:9222/devtools/browser/..."
 
 ## Session ID Management
 
-### Current Session
+### Current Session (interactive terminal only)
 
-When you start a session, it becomes the "current session" automatically:
+When you start a session from an interactive terminal, it becomes the "current session" automatically:
 
 ```bash
 notte sessions start
@@ -81,6 +81,8 @@ notte page click "B3"
 notte page scrape
 notte sessions stop
 ```
+
+This convenience is **only available in an interactive terminal**. In scripts, subagents, CI, and parallel workers, the CLI does not write `~/.notte/cli/current_session` - the file is a single shared slot and parallel workers used to race on it, stopping each other's sessions. Scripted callers must capture the session ID explicitly (see [Scripted use](#scripted-use) below).
 
 ### Explicit Session ID
 
@@ -97,7 +99,34 @@ notte page observe
 
 1. `--session-id` flag (highest)
 2. `NOTTE_SESSION_ID` environment variable
-3. Current session file (set by `sessions start`)
+3. `~/.notte/cli/current_session` file (only written by `sessions start` in interactive terminals)
+
+### Scripted use
+
+In any non-interactive context (script, subagent, CI, parallel worker), capture the session ID from `sessions start -o json` and pass it explicitly on every follow-up call:
+
+```bash
+set -euo pipefail
+
+SESSION_ID=$(notte sessions start --headless -o json | jq -r '.session_id')
+trap 'notte sessions stop --session-id "$SESSION_ID" --yes 2>/dev/null || true' EXIT
+
+notte page goto "https://example.com" --session-id "$SESSION_ID"
+notte page observe --session-id "$SESSION_ID"
+notte page scrape --instructions "Extract titles" --session-id "$SESSION_ID"
+```
+
+To avoid repeating `--session-id` on every line, export `NOTTE_SESSION_ID` for the duration of the script:
+
+```bash
+export NOTTE_SESSION_ID=$(notte sessions start --headless -o json | jq -r '.session_id')
+trap 'notte sessions stop --yes 2>/dev/null || true; unset NOTTE_SESSION_ID' EXIT
+
+notte page goto "https://example.com"
+notte page observe
+```
+
+For parallel workers, give each worker its own local `SESSION_ID` - never share a session across workers (the underlying browser session is single-tenant) and never rely on the current-session file to communicate between them.
 
 ## Observing Page State
 


### PR DESCRIPTION
## Summary

Companion docs PR to [nottelabs/notte-cli#43](https://github.com/nottelabs/notte-cli/pull/43), which fixes a parallel-worker race where `notte sessions start` from a non-TTY context would stop sibling processes' live sessions.

After that fix, the CLI **no longer writes** `~/.notte/cli/current_session` (or `current_agent`) when stdin is not a terminal. Scripted callers must capture the ID from the start output and thread it explicitly on every follow-up call. This PR updates the `notte-browser` skill so subagents and script authors don't keep producing the broken pattern.

## What's in this PR

`plugins/notte-cli/skills/notte-browser/SKILL.md`:
- Split the "current session/agent" notes into **interactive terminal** vs **non-interactive** behavior. Interactive use is unchanged.
- Added a new top-level **Scripted and parallel use** section with three copy-paste recipes:
  - Single-script: `SESSION_ID=$(notte sessions start -o json | jq -r .session_id)` and pass `--session-id "$SESSION_ID"` everywhere.
  - `NOTTE_SESSION_ID` export for terser scripts.
  - Parallel-worker template, with `trap` cleanup so leaked sessions don't survive a `set -e` failure.
- Updated **Session ID Resolution** so item 3 calls out that the file is interactive-only.

`plugins/notte-cli/skills/notte-browser/references/session-management.md`:
- Mirrored the same split (interactive vs non-interactive) under **Current Session**.
- Added a parallel **Scripted use** subsection.
- Updated priority-order text to match SKILL.md.

## Why this matters

Subagents and CC-style flows run with EOF stdin by default. Before the CLI fix, they'd silently stop sibling sessions; after the CLI fix, they'd silently no-op on `notte page observe` because `current_session` is empty. Either way the symptom is confusing if the docs still tell them the file is the canonical source. This PR makes the explicit `--session-id` pattern the documented path for any non-interactive flow.

## Test plan

- [x] Manual readthrough of SKILL.md and session-management.md - flows and anchors are consistent
- [ ] Sanity-check on a published version of the skill once the CLI PR is merged: subagent run starts a session, calls `page observe`, and stops it, all via `--session-id "$SESSION_ID"`.