### PR TITLE
docs: document browser profiles

### DIFF
--- a/plugins/notte-cli/skills/notte-browser/SKILL.md
+++ b/plugins/notte-cli/skills/notte-browser/SKILL.md
@@ -101,6 +101,8 @@ notte sessions start [flags]
   --proxy                    Use default proxies
   --proxy-country <code>     Proxy country code (e.g. us, gb, fr)
   --solve-captchas           Automatically solve captchas
+  --profile-id <profile-id>  Load browser state from a profile
+  --profile-persist          Save browser state back to the profile on session close
   --viewport-width           Viewport width in pixels
   --viewport-height          Viewport height in pixels
   --user-agent               Custom user agent string
@@ -118,6 +120,8 @@ notte sessions list [--page N] [--page-size N] [--only-active]
 ```
 
 **Note:** When you start a session, it automatically becomes the "current" session (i.e NOTTE_SESSION_ID environment variable is set). All subsequent commands use this session by default. Use `--session-id <session-id>` only when you need to manage multiple sessions simultaneously or reference a specific session.
+
+**Browser profiles:** Profiles store browser state such as cookies, `localStorage`, and `sessionStorage`. Start a session with `--profile-id <profile-id>` to load that saved state; add `--profile-persist` when starting the session if changes should be saved back to the profile when the session closes.
 
 Session debugging and export:
 

--- a/plugins/notte-cli/skills/notte-browser/references/session-management.md
+++ b/plugins/notte-cli/skills/notte-browser/references/session-management.md
@@ -51,11 +51,17 @@ notte sessions start \
   --max-duration-minutes 60 \     # Maximum 60 min session lifetime
   --proxy \                       # Use rotating proxies
   --solve-captchas \              # Auto-solve CAPTCHAs
+  --profile-id <profile-id> \     # Load browser state from a profile
+  --profile-persist \             # Save browser state on session close
   --viewport-width 1920 \         # Custom viewport
   --viewport-height 1080 \
   --user-agent "Custom UA" \      # Custom user agent
   --use-file-storage              # Enable file storage for downloads
 ```
+
+### Browser Profiles
+
+Profiles store browser state such as cookies, `localStorage`, and `sessionStorage`. Start a session with `--profile-id <profile-id>` to load that saved state; add `--profile-persist` when starting the session if changes should be saved back to the profile when the session closes.
 
 ### Remote Browser Connection
 


### PR DESCRIPTION
## Summary
- Add profile-related session start flags to the Notte CLI skill docs
- Document that profiles load/save cookies, localStorage, and sessionStorage via --profile-id and --profile-persist

## Testing
- Not run; docs-only change