### PR TITLE
fix(notte-browser): correct run-output field and status assumption

### DIFF
--- a/plugins/notte-cli/skills/notte-browser/references/function-management.md
+++ b/plugins/notte-cli/skills/notte-browser/references/function-management.md
@@ -82,7 +82,7 @@ notte functions create \
   --description "Scrapes top stories from Hacker News"
 
 # 5. Test the function
-RUN_ID=$(notte functions run -o json | jq -r '.run_id')
+RUN_ID=$(notte functions run -o json | jq -r '.function_run_id')
 echo "Started run: $RUN_ID"
 
 # Wait a few seconds for execution
@@ -100,7 +100,7 @@ notte functions run-metadata --run-id "$RUN_ID" -o json | jq '{
 notte functions update --file hn_scraper.py
 
 # Test again
-RUN_ID=$(notte functions run -o json | jq -r '.run_id')
+RUN_ID=$(notte functions run -o json | jq -r '.function_run_id')
 sleep 10
 notte functions run-metadata --run-id "$RUN_ID"
 
@@ -115,6 +115,7 @@ notte functions schedule --cron "0 9 * * *"
 - **Monitor logs**: The `logs` field in run-metadata shows print statements and errors
 - **Use variables**: Add function parameters for flexibility (e.g., `max_stories` in the example)
 - **Return data**: Always return structured data from your `run()` function for easy access via run-metadata
+- **Read `result`, not `status` alone**: `notte functions run -o json` blocks until the run finishes and returns `status` and `result` inline. A script error may report `status: "failed"`, but an error inside `run()` can also come back as `status: "closed"` with the traceback in `result`. So treat a `result` that is a JSON object as success, and a `result` that is an error string (`Script execution failed` / `Traceback`) as a failure - do not rely on `status` alone. The run id field in the JSON is `function_run_id`.
 
 ## Creating Functions
 
@@ -534,8 +535,10 @@ notte functions run-metadata --run-id <run-id> -o json
 ### 3. Monitor Run History
 
 ```bash
-# Check for failed runs
-notte functions runs -o json | jq '.[] | select(.status == "failed")'
+# Check for failed runs. A script error may report status "failed", but an error
+# inside run() can also come back as status "closed" with the error string in
+# `result`, so match both.
+notte functions runs -o json | jq '.[] | select(.status == "failed" or ((.result|type) == "string" and (.result|test("Script execution failed|Traceback"))))'
 ```
 
 ### 4. Test Before Scheduling


### PR DESCRIPTION
## What

Fixes two factual bugs in the base `notte-browser` skill's `function-management.md` that cause its copy-paste examples to fail or mislead. Both were found while building (and live-benchmarking) the forge/doctor skills, and are verified against the Go CLI source and live prod.

## The bugs

1. **Wrong run-id field.** The test/iterate examples extract the run id with `jq -r '.run_id'`, but `notte functions run -o json` returns the field as **`function_run_id`** (the Go `GetFunctionRunResponse`). `.run_id` is `null`, so `RUN_ID` is empty and the subsequent `run-metadata --run-id "$RUN_ID"` calls don't resolve a run. Fixed both occurrences. (The `--run-id` *flag* name is correct and unchanged.)

2. **`status == "failed"` assumption.** The "check for failed runs" example filters on `status == "failed"`. The status enum is `active`/`closed`/`failed`, but a script error (assertion/exception) has been observed on prod to come back as **`status: "closed"` with the traceback in `result`**, so a status-only filter silently misses failures. The filter now matches `status == "failed"` **or** a `result` string containing `Script execution failed`/`Traceback`, and a Tips note explains reading `result` rather than relying on `status` alone.

## Verification

- Go CLI source: `GetFunctionRunResponse` has `function_run_id`, `result` (string), `status` ∈ {active, closed, failed}.
- Live prod: a deliberately-failing Function returned `status:"closed"` with the error in `result`; `notte functions run -o json` exposes `function_run_id` (not `run_id`).
- The new `jq` filter was validated to select only failed runs and to not error on success (object) or null `result`.

Scope: a single reference file; no behavior or other skills touched. Separate from #16 (the forge/doctor skills), which already carry the corrected guidance.
