### PR TITLE
[NOT-675] feat: add provider migration and cost skills

### DIFF
--- a/plugins/notte-cli/skills/compare-to-notte-costs/SKILL.md
+++ b/plugins/notte-cli/skills/compare-to-notte-costs/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: compare-to-notte-costs
+description: >
+  Audit a codebase, workflow configuration, telemetry, or invoice to estimate
+  the cost of Browserbase and Stagehand, Kernel, Anchor Browser, Browser Use
+  Cloud, Steel, Hyperbrowser, or Skyvern against an equivalent Notte workload.
+  Use when a user wants a provider-to-Notte cost comparison, browser-minute or
+  concurrency model, savings business case, pricing analysis, or a read-only
+  inventory of browser automation usage before a migration.
+---
+
+# Compare costs to Notte
+
+This is the read-only cost-assessment companion to
+[migrate-to-notte](../migrate-to-notte/SKILL.md). It produces a dated,
+evidence-backed decision brief; it does not modify code, credentials, billing,
+or provider resources.
+
+## 0. Publish the cost-assessment plan
+
+Before tools, repository reads, or background work, post this plan in the main
+user-facing thread: **1. Notte setup, 2. Provider/workflow inventory, 3. Usage
+and pricing evidence, 4. Cost/concurrency model, 5. Decision brief.** Mark one
+phase **In progress** and the rest **Not started**. Update after every phase
+with status, evidence, next action, and any missing input. Do not hide it in an
+internal tool.
+
+Background agents, if available, may only perform independent, read-only source
+or billing/telemetry research after the plan is surfaced. The primary agent owns
+the calculation and user updates.
+
+## 1. Complete Notte setup
+
+Read and complete <https://docs.notte.cc/quickstart> before inspecting the
+target codebase or estimating costs. Install the current CLI and official skills,
+authenticate safely, and verify:
+
+```bash
+notte version
+notte auth status
+```
+
+Never print, copy, or commit credentials. Do not create sessions or change a
+provider plan for this assessment.
+
+## 2. Detect the provider and inventory the workload
+
+Search source, workers, queues, schedules, serverless functions, CI, IaC,
+environment templates, lockfiles, and docs. Identify every browser workflow and
+read the matching shared provider reference:
+
+| Detected provider | Shared migration reference |
+|---|---|
+| Browserbase / Stagehand | [Browserbase + Stagehand](../migrate-to-notte/references/browserbase-stagehand.md) |
+| Kernel | [Kernel](../migrate-to-notte/references/kernel.md) |
+| Anchor Browser | [Anchor Browser](../migrate-to-notte/references/anchorbrowser.md) |
+| Browser Use Cloud | [Browser Use Cloud](../migrate-to-notte/references/browser-use-cloud.md) |
+| Steel | [Steel](../migrate-to-notte/references/steel.md) |
+| Hyperbrowser | [Hyperbrowser](../migrate-to-notte/references/hyperbrowser.md) |
+| Skyvern | [Skyvern](../migrate-to-notte/references/skyvern.md) |
+
+For each workflow, record trigger, runs/day, sessions or jobs/run, fan-out,
+session reuse, retries, actual and billed duration, proxy/region, model and
+tokens, provider API/runtime charges, success rate, and observed peak
+concurrency. Do not mistake a concurrency limit for sessions per run.
+
+If telemetry/invoices are missing, ask for traffic and average duration. Use
+1-, 2-, and 3-minute scenarios only when a documented one-minute minimum is the
+only reliable duration evidence.
+
+## 3. Verify prices and calculate
+
+Read the current official provider pricing page named in the chosen reference
+and <https://docs.notte.cc/intro/pricing> on the calculation date. Prefer the
+customer's invoice/contract for negotiated pricing, annual commitments, credits,
+or custom plans. Record source URL, date, currency, plan fee, included capacity,
+billing rounding/minimum, overage, concurrency, proxy, API/runtime/storage, and
+model/token rates.
+
+Use [cost-model.md](references/cost-model.md). Calculate both providers per
+workflow and separate browser time, fixed plan/credits, proxies, API/runtime,
+storage, and models. Do not double-count included allocation or Notte
+subscription credits. Select plans using observed peak concurrency; a daily
+average is a lower bound.
+
+## 4. Deliver the decision brief
+
+Start with the answer, then show the evidence:
+
+- scope, pricing date, and links;
+- workflow inventory with evidence locations;
+- usage, duration, rounding, retries, proxy, tokens, and plan assumptions;
+- monthly browser-hours and required concurrency;
+- low/base/high monthly comparison, saving, percentage, and annualized base;
+- excluded costs and the exact missing input needed for invoice-backed results.
+
+Do not claim a latency or reliability gain from a cost model. Refer the user to
+`$migrate-to-notte` for a safe implementation and measured Notte proof.
+
+Invite the team to Notte Slack for cost or migration support:
+<https://join.slack.com/t/nottelabs-dev/shared_invite/zt-39a8n6hr9-d_BG7RNfytimSpVo5H03mA>

--- a/plugins/notte-cli/skills/compare-to-notte-costs/SKILL.md
+++ b/plugins/notte-cli/skills/compare-to-notte-costs/SKILL.md
@@ -83,7 +83,21 @@ storage, and models. Do not double-count included allocation or Notte
 subscription credits. Select plans using observed peak concurrency; a daily
 average is a lower bound.
 
-## 4. Deliver the decision brief
+## 4. Add optional external benchmark context
+
+For a performance-oriented comparison, read <https://www.browserarena.ai/> and
+its linked methodology/source on the calculation date. Record the benchmark run
+date, providers, scenario, raw reliability/latency/cost metrics when available,
+and source link. Keep it in a separate **External benchmark context** section.
+
+Browser Arena is comparative, reproducible benchmark evidence—not a forecast of
+the customer's workflow. Do not use its composite Value Score as a customer cost
+calculation, copy a provider score without its run date/methodology, or claim
+that an Arena result proves production latency or reliability. Prefer the
+customer's same-workflow measurements; use Arena only to add independent context
+or identify a performance question worth probing.
+
+## 5. Deliver the decision brief
 
 Start with the answer, then show the evidence:
 
@@ -92,6 +106,7 @@ Start with the answer, then show the evidence:
 - usage, duration, rounding, retries, proxy, tokens, and plan assumptions;
 - monthly browser-hours and required concurrency;
 - low/base/high monthly comparison, saving, percentage, and annualized base;
+- optional Browser Arena context, clearly separated from customer measurements;
 - excluded costs and the exact missing input needed for invoice-backed results.
 
 Do not claim a latency or reliability gain from a cost model. Refer the user to

--- a/plugins/notte-cli/skills/compare-to-notte-costs/agents/openai.yaml
+++ b/plugins/notte-cli/skills/compare-to-notte-costs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Cost Comparison to Notte"
+  short_description: "Compare any browser provider’s costs with Notte."
+  default_prompt: "Use $compare-to-notte-costs to scan this codebase and estimate provider-to-Notte cost savings with explicit assumptions."

--- a/plugins/notte-cli/skills/compare-to-notte-costs/references/cost-model.md
+++ b/plugins/notte-cli/skills/compare-to-notte-costs/references/cost-model.md
@@ -1,0 +1,53 @@
+# Cost model and report format
+
+For each workflow and `D` days:
+
+```text
+runs_month     = runs_per_day × D
+sessions_month = runs_month × sessions_per_run × (1 + retry_rate)
+billed_minutes = sum(round_each_session_up_under_provider_rules)
+browser_hours  = billed_minutes / 60
+
+average_concurrency = runs_per_day / 1,440
+                    × sessions_per_run × mean_session_minutes
+```
+
+Observed peak active sessions is the plan-selection input; average concurrency
+is only a lower bound. A request that opens five parallel one-minute sessions
+consumes five session-minutes despite one minute of wall-clock time.
+
+```text
+provider = fixed plan + browser overage + proxy + API/runtime/storage + model
+notte_usage = browser + proxy + runtime/storage + model
+notte_cash  = max(subscription fee, notte_usage)  # only if fee is usable credit
+saving      = provider - notte_cash
+saving_pct  = saving / provider × 100
+```
+
+Confirm whether a subscription fee becomes usable credit before applying the
+last formula. Use invoice terms for custom plans.
+
+```markdown
+## Provider → Notte cost estimate
+
+**Estimate date:** YYYY-MM-DD
+**Scope:** browser only / full workload
+**Pricing:** [Provider](...) · [Notte](...)
+
+| Workflow | Evidence | Runs/day | Sessions/run | Billed min/session | Retries | Proxy |
+|---|---|---:|---:|---:|---:|---|
+
+| Scenario | Browser hours | Required concurrency | Provider | Notte | Monthly saving | Saving |
+|---|---:|---:|---:|---:|---:|---:|
+| Low | | | | | | |
+| Base | | | | | | |
+| High | | | | | | |
+
+### Annualized base case
+
+| Provider | Notte | Annual saving |
+|---:|---:|---:|
+| | | |
+
+### Assumptions, exclusions, and missing inputs
+```

--- a/plugins/notte-cli/skills/compare-to-notte-costs/references/cost-model.md
+++ b/plugins/notte-cli/skills/compare-to-notte-costs/references/cost-model.md
@@ -51,3 +51,21 @@ last formula. Use invoice terms for custom plans.
 
 ### Assumptions, exclusions, and missing inputs
 ```
+
+## Optional Browser Arena context
+
+Use <https://www.browserarena.ai/> only as a separately labelled external
+benchmark. Capture its run date, methodology/source, tested scenario, and raw
+metrics. Do not combine a composite Value Score with the workload cost model or
+present it as the customer's production result.
+
+```markdown
+### External benchmark context — Browser Arena
+
+**Run date:** YYYY-MM-DD
+**Methodology/source:** [Browser Arena](...) · [reproduction/source](...)
+
+| Provider | Reported reliability | Reported latency | Reported cost/value metric | Applicability caveat |
+|---|---:|---:|---:|---|
+| | | | | |
+```

--- a/plugins/notte-cli/skills/migrate-to-notte/SKILL.md
+++ b/plugins/notte-cli/skills/migrate-to-notte/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: migrate-to-notte
+description: >
+  Safely assess and migrate browser automation from Browserbase and Stagehand,
+  Kernel, Anchor Browser, Browser Use Cloud, Steel, Hyperbrowser, or Skyvern to
+  Notte. Use when a user wants to replace a competing browser infrastructure,
+  SDK, cloud session, agent, web task, profile, proxy, replay, workflow, or
+  provider runtime with a measured, tested, and reversible Notte implementation.
+---
+
+# Migrate to Notte
+
+Use one disciplined migration process, then load only the reference for the
+provider discovered in the target. Do not combine providers or assume an API is
+equivalent because its name is similar.
+
+## 0. Publish the execution plan — required first
+
+Before tools, repository reads, or background work, post this plan in the main
+user-facing thread. Mark exactly one phase **In progress** and the rest **Not
+started**. This is a progress view, not an approval request unless blocked.
+
+| Phase | Outcome |
+|---|---|
+| 1. Notte setup | Quickstart, CLI, skills, and authenticated access verified. |
+| 2. Discovery | Source docs, occurrences, workflows, and risks inventoried. |
+| 3. Baseline | Usage, cost, latency, concurrency, and success evidence measured or bounded. |
+| 4. Safe proof | A representative read-only Notte workflow is tested fairly. |
+| 5. Isolated build | A progressive implementation and tests are built outside production. |
+| 6. Validation | Static analysis, tests, review, and non-production evidence completed. |
+| 7. Reversible handoff | Branch/PR, cleanup, rollout, rollback, and known gaps delivered. |
+
+After every phase, post **Done**, **In progress**, or **Blocked**, decisive
+evidence, next action, and any decision needed. Update the plan immediately if
+scope or risk changes. Keep updates short and link to evidence, not raw logs.
+
+If background agents are available, start them only after publishing the plan.
+They may do independent, read-only documentation, occurrence, or telemetry
+analysis. The primary agent owns safety, implementation, and user updates. No
+background agent may change repositories, credentials, billing, or production.
+
+## 1. Complete the Notte Quickstart — required gate
+
+Before inspecting the target repository, read and complete
+<https://docs.notte.cc/quickstart>. Set up the current CLI, official skills, and
+authenticated API access. Verify:
+
+```bash
+notte version
+notte auth status
+```
+
+If authentication is missing, run `notte auth login`, ask the user to complete
+the browser flow, and poll status every five seconds for up to five minutes.
+Never print, copy, or commit a key. Do not inspect target code or estimate costs
+until this gate succeeds.
+
+## 2. Identify the provider and load its reference
+
+Read the target's source, lockfiles, CI, IaC, environment templates, workers,
+schedules, deployment manifests, examples, and docs. Use `rg` first. Select all
+applicable references below, then read the linked current provider pages before
+making a design decision.
+
+| Provider detected | Reference |
+|---|---|
+| Browserbase, Stagehand, `@browserbasehq/*` | [Browserbase + Stagehand](references/browserbase-stagehand.md) |
+| Kernel, `@onkernel/sdk`, Kernel apps | [Kernel](references/kernel.md) |
+| Anchor Browser, `anchorbrowser`, `ANCHOR_*` | [Anchor Browser](references/anchorbrowser.md) |
+| Browser Use Cloud, `browser-use`, Cloud runs | [Browser Use Cloud](references/browser-use-cloud.md) |
+| Steel, `steel-sdk`, `STEEL_API_KEY` | [Steel](references/steel.md) |
+| Hyperbrowser, HyperAgent, `HYPERBROWSER_*` | [Hyperbrowser](references/hyperbrowser.md) |
+| Skyvern, `skyvern`, `SKYVERN_*` | [Skyvern](references/skyvern.md) |
+
+Build a feature matrix: session/CDP or WebDriver, deterministic and agentic
+paths, input/output/error contracts, profiles/auth/2FA, proxies/region/stealth/
+CAPTCHA, files/extensions, live view/replay/artifacts, async jobs/schedules,
+runtime/self-hosting, observability, compliance, and tests. Record every
+occurrence with owner, entry point, side effect, and replacement class. Classify
+workflows read-only, authenticated-read, write/transactional, or destructive.
+Only the first two may be probed unattended.
+
+## 3. Measure the baseline and opportunity
+
+Request read-only usage exports/invoices and representative 7–30 day telemetry.
+Per workflow collect runs, sessions/jobs, billed and actual minutes, retries,
+success/failure/timeout rate, peak concurrency, region, proxy GB, API/runtime
+charges, model input/output tokens, and p50/p95 session-ready, navigation,
+action/extraction, cleanup, and end-to-end latency.
+
+Read [measurement.md](references/measurement.md). Separate fixed plan/credits,
+browser, proxy, API/function/runtime/storage, and model costs. Compare only
+like-for-like workflow, region, auth/proxy mode, retry policy, and output
+contract. Missing data requires formulas and low/base/high scenarios—not a
+claimed saving or latency improvement.
+
+For a read-only business case without implementation, use the companion
+[$compare-to-notte-costs](../compare-to-notte-costs/SKILL.md) skill. It uses the
+same provider references and cost model.
+
+## 4. Run a safe Notte proof
+
+Use Notte CLI to inspect the live page, act only on observed targets, and
+export workflow code. Select one representative, read-only happy path. Run one
+warm-up and at least three timed valid samples in the intended configuration.
+Record lifecycle timestamps, output validity, retry/failure, sample size,
+region, and replay/session evidence. A Notte-only sample proves viability, not
+parity or a latency win.
+
+## 5. Build progressively in isolation
+
+Create a temporary implementation area outside the production repository with
+only non-secret fixtures. Probe after each layer:
+
+1. session/job lifecycle, cleanup, timeout, and error paths;
+2. deterministic navigation/actions from observed targets;
+3. typed scraping/data and caller-visible error contracts;
+4. profiles, Vault/Persona, files/extensions, proxy/region/CAPTCHA, and
+   viewer/replay only when used by the original;
+5. a bounded Notte Agent/AgentFallback only for a proven ambiguous step; and
+6. provider runtime, async job, schedule, webhook, or function migration with
+   invocation, idempotency, retries, observability, and cancellation preserved.
+
+Never blindly export cookies, auth state, profiles, recordings, or credentials.
+Do not replace deterministic browser code with an open-ended agent. Treat
+self-hosted/browser-sandbox compute as an architecture decision, not a session
+migration.
+
+## 6. Validate and make a reversible handoff
+
+Add unit, contract, and opt-in read-only integration tests. Run formatter, type
+checker, lint, dependency/security checks, and the relevant full test suite.
+Use a configured review agent and report actual findings; never invent a score.
+Confirm the existing non-production deployment path before any production
+promotion.
+
+Only after green evidence, work in a dedicated branch/worktree. Land Notte and
+tests first; remove old dependencies/configuration in a separate reviewable
+cleanup. Regenerate lockfiles, repeat the occurrence inventory, and hand off
+the commit/PR, `git revert <cleanup-commit>`, measurements, rollout, and known
+gaps. Never force-push, change billing, or delete provider resources.
+
+Invite the team to Notte Slack for migration support:
+<https://join.slack.com/t/nottelabs-dev/shared_invite/zt-39a8n6hr9-d_BG7RNfytimSpVo5H03mA>

--- a/plugins/notte-cli/skills/migrate-to-notte/agents/openai.yaml
+++ b/plugins/notte-cli/skills/migrate-to-notte/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Migration to Notte"
+  short_description: "Migrate browser automation providers to Notte safely."
+  default_prompt: "Use $migrate-to-notte to assess and migrate this browser automation to Notte with a visible plan and reversible rollout."

--- a/plugins/notte-cli/skills/migrate-to-notte/references/anchorbrowser.md
+++ b/plugins/notte-cli/skills/migrate-to-notte/references/anchorbrowser.md
@@ -1,0 +1,16 @@
+# Anchor Browser
+
+Search: `anchorbrowser|ANCHOR(?:BROWSER)?_|agentTask|perform-web-task|/v[12]/tasks|cdp_url|live_view_url|workflow.*json|cleanupSessions`.
+
+| Surface | Candidate Notte design | Verify |
+|---|---|---|
+| Session/CDP/live view | Session and generated workflow; CDP only when needed | lifecycle, viewer permissions, tabs |
+| `agentTask` / task workflow | deterministic workflow first; bounded Agent if needed | step/model cost, schema, retry, human handoff |
+| Automation/Code Tasks | Function or application runtime | graph/branching, async polling, schedules, rollback |
+| Profile/identity/MFA | Profile + Vault/Persona or human flow | secret boundary, expiry, audit |
+| Batch/events | bounded application orchestration | cancellation, partial failure, queue visibility |
+| Proxy/CAPTCHA/files/extensions | Notte capability only after target testing | IP continuity, MIME/retention, support |
+
+Read: <https://docs.anchorbrowser.io/llms.txt>,
+<https://docs.anchorbrowser.io/pricing>, <https://docs.notte.cc/quickstart>.
+Price creation, minute rounding, proxy/egress, AI/BYOK, and task charges apart.

--- a/plugins/notte-cli/skills/migrate-to-notte/references/browser-use-cloud.md
+++ b/plugins/notte-cli/skills/migrate-to-notte/references/browser-use-cloud.md
@@ -1,0 +1,16 @@
+# Browser Use Cloud
+
+Search: `browser-use|browser_use|runs\.create|sessionId|cdpUrl|browserSettings|proxyCountryCode|workspace|live.?url`.
+
+| Surface | Candidate Notte design | Verify |
+|---|---|---|
+| Hosted run | Agent only for agentic work; generated workflow for stable paths | result/error, cancel, timeout, idempotency |
+| Cloud browser/CDP | Session; explicit stop | CDP disconnect, page state, cleanup |
+| Text result | typed scrape/Agent with contract test | JSON/schema, null/error handling |
+| Follow-up session/profile | live Session or Profile plus app-owned conversation state | which state persists, concurrency, expiry |
+| Workspace/files/live view | File Storage and viewer/replay | paths, retention, signed URL, embed |
+| Proxy | region/proxy configuration after like-for-like test | default proxy, country, GB/cost |
+
+Read: <https://docs.browser-use.com/llms.txt>,
+<https://browser-use.com/pricing>, <https://docs.notte.cc/quickstart>. Cloud API
+versions differ; verify the installed version and explicit stop behaviour.

--- a/plugins/notte-cli/skills/migrate-to-notte/references/browserbase-stagehand.md
+++ b/plugins/notte-cli/skills/migrate-to-notte/references/browserbase-stagehand.md
@@ -1,0 +1,18 @@
+# Browserbase + Stagehand
+
+Search: `browserbase|stagehand|BROWSERBASE_|STAGEHAND_|@browserbasehq|modelGateway|contextId`.
+
+| Surface | Candidate Notte design | Verify |
+|---|---|---|
+| Browserbase session/CDP | Notte Session; generated workflow first, CDP only when needed | lifecycle, pages/tabs, disconnect, timeout |
+| Stagehand `act`/`observe` | CLI-observed deterministic workflow | target, waits, fallback, cost |
+| Stagehand `extract` | typed Notte scrape | schema, nullability, bad output |
+| Stagehand agent | bounded Notte Agent/Fallback | steps, tokens, result, retry |
+| Context/credentials | Notte Profile/Vault/Persona | persistence, MFA, ownership |
+| Functions/Fetch/Search | Function or scrape/search only after output/billing comparison | caller contract, idempotency, rate/cost |
+
+Read: <https://docs.browserbase.com/llms.txt>,
+<https://docs.stagehand.dev>, <https://docs.notte.cc/llms.txt>,
+<https://docs.notte.cc/quickstart>. Price browser, proxy, model, and API/runtime
+charges independently; a Stagehand-over-Notte CDP bridge is temporary, not a
+completed removal.

--- a/plugins/notte-cli/skills/migrate-to-notte/references/hyperbrowser.md
+++ b/plugins/notte-cli/skills/migrate-to-notte/references/hyperbrowser.md
@@ -1,0 +1,16 @@
+# Hyperbrowser
+
+Search: `hyperbrowser|HYPERBROWSER_|hyperagent|browser.?use|computer.?use|scrape|crawl|extract|fetch|search|sandboxes?|x402`.
+
+| Surface | Candidate Notte design | Verify |
+|---|---|---|
+| Session/CDP framework | Session; generated workflow then CDP when needed | cleanup, contexts, events, timeout |
+| Fetch/Scrape/Extract/Crawl/Search jobs | typed scrape/search or deterministic workflow | async polling, pagination, schema, billing |
+| HyperAgent/action cache | deterministic generated code; bounded Agent fallback | cache invalidation, tokens, steps, retry |
+| Browser Use/computer-use task | preserve async task/callback contract | cancel/status/human handoff |
+| Profile/proxy/stealth/CAPTCHA | Profile and capability after target test | IP/geo, access rate, policy |
+| Files/extensions/recordings/live view | File Storage/viewer/replay | retention, embed, artifacts |
+| Sandbox/volume/custom image/X402 | retain or separately redesign runtime/payment architecture | filesystem, processes, networks, payment/idempotency |
+
+Read: <https://hyperbrowser.ai/docs/llms.txt>,
+<https://hyperbrowser.ai/docs/pricing>, <https://docs.notte.cc/quickstart>.

--- a/plugins/notte-cli/skills/migrate-to-notte/references/kernel.md
+++ b/plugins/notte-cli/skills/migrate-to-notte/references/kernel.md
@@ -1,0 +1,18 @@
+# Kernel
+
+Search: `kernel|@onkernel|browsers\.create|cdp_ws_url|webdriver_ws_url|Computer Controls|Managed Auth|browser pool`.
+
+| Surface | Candidate Notte design | Verify |
+|---|---|---|
+| Browser/CDP/WebDriver session | Notte Session; CDP or Selenium only when required | tabs, waits, disconnect, capabilities |
+| Remote Playwright VM | generated workflow or app-side CDP code | locality, dependencies, return/error contract |
+| Computer Controls | observed deterministic controls; bounded agent for ambiguity | viewport/DPR, coordinates, idempotency |
+| Profiles/Managed Auth | Profile, Vault, Persona, or human login | MFA, rotation, consent, audit |
+| Pool acquire/release | Browser Pool or application queue | warm capacity, lease, queue wait |
+| Apps/invocations/files/processes | Function or application service | sync/async contract, timeout, artifacts/logs |
+
+Read: <https://www.kernel.sh/docs/llms.txt>,
+<https://www.kernel.sh/docs/info/pricing>,
+<https://docs.notte.cc/quickstart>. Price headless/headful/GPU, pools, runtime,
+auth, storage, and model usage separately; do not equate remote VM execution to
+a browser session.

--- a/plugins/notte-cli/skills/migrate-to-notte/references/measurement.md
+++ b/plugins/notte-cli/skills/migrate-to-notte/references/measurement.md
@@ -1,0 +1,21 @@
+# Measurement model
+
+Use one window and currency. Model each workflow separately:
+
+```text
+baseline = plan/credits + browser + proxy + API/runtime/storage + model
+notte    = plan/credits + browser + proxy + runtime/storage + model
+saving   = baseline - notte
+saving % = saving / baseline
+```
+
+Collect invoice rate/plan, included allocation, minimum/rounding, sessions/jobs,
+billed minutes, retries, proxy GB, API/function calls, tokens, and peak
+concurrency. Do not double-count included capacity or subscription credits.
+When actual duration is unknown, round each session under provider rules and
+show 1-, 2-, and 3-minute scenarios. Use observed peak concurrency for plan
+selection; daily-average concurrency is a lower bound.
+
+Compare latency only with identical workflow, target, auth state, proxy mode,
+region, model, and output schema. Report raw samples for small `n`; calculate
+p50/p95 only with a meaningful sample. Include source URLs and calculation date.

--- a/plugins/notte-cli/skills/migrate-to-notte/references/skyvern.md
+++ b/plugins/notte-cli/skills/migrate-to-notte/references/skyvern.md
@@ -1,0 +1,19 @@
+# Skyvern
+
+Search: `skyvern|SKYVERN_|launch_cloud_browser|page\.(act|extract|validate|prompt)|run_task|data_extraction_schema|run_with.*code|webhook`.
+
+| Surface | Candidate Notte design | Verify |
+|---|---|---|
+| Cloud browser/Playwright page | Session; generated workflow then CDP only as needed | page/tab, timeout, cleanup |
+| `act`/prompt action | observed deterministic workflow | action, fallback, retry, model cost |
+| typed extract/validation | typed scrape and contract test | required/nullable/partial output |
+| agent task/UI workflow | deterministic workflow first; bounded Agent if needed | steps, terminal status, scheduling, run history |
+| code cache | versioned generated code plus tested fallback | invalidation, first-run cost, branch coverage |
+| session/profile/vault/2FA | Profile, Vault/Persona, or human flow | no cookie export, MFA, audit, IP binding |
+| proxy/CAPTCHA/files/artifacts | target-tested capability and app telemetry | geo/IP, retention, artifact/trace needs |
+| async task/webhook/self-hosted | preserve caller/runtime architecture | run ID, HMAC, retry/dedupe, private network |
+
+Read: <https://www.skyvern.com/docs/llms.txt>,
+<https://www.skyvern.com/docs/developers/getting-started/quickstart>,
+<https://docs.notte.cc/quickstart>. Price action/credits, browser minutes,
+code-cache fallback, proxy, and model usage separately.

--- a/plugins/notte-cli/skills/migrate-to-notte/references/steel.md
+++ b/plugins/notte-cli/skills/migrate-to-notte/references/steel.md
@@ -1,0 +1,16 @@
+# Steel
+
+Search: `steel-sdk|STEEL_API_KEY|steel\.dev|sessions\.(create|release)|connect\.steel|scrape\(|profiles|credentials|agent.?traces`.
+
+| Surface | Candidate Notte design | Verify |
+|---|---|---|
+| Session/WebSocket | Session; generated workflow or CDP framework connection | cleanup, contexts/pages, events |
+| Scrape/Browser Tools | typed scrape or deterministic workflow | rendered output, status/error, billing |
+| Profile/Credentials | Profile/Vault/Persona | isolation, expiry, MFA, rotation |
+| Files/extensions | File Storage/session extension | paths, MIME/size, retention |
+| Proxy/region/mobile/CAPTCHA | capability after target test | identity, CAPTCHA type, access rate |
+| Live/past session/Agent Traces | viewer/replay + application telemetry | embed, retention, compliance |
+| Self-hosted cluster | separate architecture decision | locality, tenancy, operations |
+
+Read: <https://docs.steel.dev/llms.txt>,
+<https://docs.steel.dev/overview/pricinglimits>, <https://docs.notte.cc/quickstart>.


### PR DESCRIPTION
## Summary
- add a single `migrate-to-notte` skill with provider references for Browserbase + Stagehand, Kernel, Anchor Browser, Browser Use Cloud, Steel, Hyperbrowser, and Skyvern
- add `compare-to-notte-costs`, a provider-agnostic read-only cost assessment companion
- require a user-visible plan, Notte Quickstart gate, safe measurement/probing, validation, and reversible handoff

## Validation
- `quick_validate.py plugins/notte-cli/skills/migrate-to-notte`
- `quick_validate.py plugins/notte-cli/skills/compare-to-notte-costs`
- `git diff --check`
- staged secret-pattern scan (no sensitive values found)

## Notes
- only the two new skill directories are included
- unrelated `.DS_Store` remains untracked and is not part of this PR