### PR TITLE
ci: add a cooldown to Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Wait before proposing a brand-new release, so a compromised or yanked
+    # version has time to be caught upstream rather than landing here the hour
+    # it is published. Security updates are exempt from cooldown, so CVE fixes
+    # still arrive immediately.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
Dependabot currently proposes a new release as soon as it is published, which is the window in which a compromised or yanked version is still undetected.

This adds a `cooldown` so a release has to age before an update is opened:

- 3 days for patches
- 7 days for minors
- 14 days for majors

Security updates are exempt from cooldown, so advisories and CVE fixes are not delayed by this.