### PR TITLE
fix: repair marketplace manifests, wire hosted MCP, add validation CI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,14 +22,6 @@
       },
       "description": "Opt-in. Cost-compare another browser automation provider against Notte from a codebase, telemetry, or invoice, and migrate to Notte with a measured, reversible rollout.",
       "source": "./plugins/notte-migrate"
-    },
-    {
-      "name": "notte-sdks",
-      "author": {
-        "name": "Notte"
-      },
-      "description": "SDK skills for building browser automation and agent workflows with Notte's Python SDK and MCP server. Use when writing code to control browsers programmatically with Notte.",
-      "source": "./plugins/notte-sdks"
     }
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "notte",
   "displayName": "Notte",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "description": "Browser automation for AI agents — real cloud or local browsers, observe/click/fill/scrape primitives, structured Pydantic extraction from dynamic pages, captcha solving and stealth mode, authenticated sessions via Vault, and one-command deployment of any browser automation as a scheduled, API-callable Notte Function.",
   "author": {
     "name": "Notte",
@@ -22,6 +22,6 @@
     "browse", "browser-automation", "cloud-browsers",
     "web-scraping", "mcp", "ai-agents", "developer-tools"
   ],
-  "skills": ["./plugins/notte/skills/", "./plugins/notte-sdks/skills/"],
+  "skills": ["./plugins/notte/skills/"],
   "rules": "./rules/"
 }

--- a/.github/workflows/test-skills.yml
+++ b/.github/workflows/test-skills.yml
@@ -3,12 +3,37 @@ name: Test Skills
 on:
   push:
     paths:
-      - 'plugins/**/templates/**'
+      - 'plugins/**'
+      - 'rules/**'
+      - 'assets/**'
+      - '.claude-plugin/**'
+      - '.cursor-plugin/**'
+      - 'scripts/validate-plugins.py'
+      - '.github/workflows/test-skills.yml'
   pull_request:
     paths:
-      - 'plugins/**/templates/**'
+      - 'plugins/**'
+      - 'rules/**'
+      - 'assets/**'
+      - '.claude-plugin/**'
+      - '.cursor-plugin/**'
+      - 'scripts/validate-plugins.py'
+      - '.github/workflows/test-skills.yml'
 
 jobs:
+  validate-manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # Also runnable locally: python3 scripts/validate-plugins.py
+      - name: Validate manifests and skill frontmatter
+        run: python3 scripts/validate-plugins.py
+
   lint-scripts:
     runs-on: ubuntu-latest
     steps:

--- a/mcp.json
+++ b/mcp.json
@@ -1,7 +1,0 @@
-{
-  "mcpServers": {
-    "notte": {
-      "url": "http://localhost:8001/sse"
-    }
-  }
-}

--- a/plugins/notte-migrate/.claude-plugin/plugin.json
+++ b/plugins/notte-migrate/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "notte-migrate",
   "version": "1.0.0",
   "description": "Opt-in skill to cost-compare another browser automation provider against Notte and migrate to Notte safely",
+  "skills": "./skills/",
   "author": {
     "name": "Notte",
     "url": "https://notte.cc"

--- a/plugins/notte/.claude-plugin/plugin.json
+++ b/plugins/notte/.claude-plugin/plugin.json
@@ -1,7 +1,9 @@
 {
   "name": "notte",
-  "version": "1.0.0",
-  "description": "Drive a real cloud or local browser with Notte — manage sessions and accounts from the CLI, and build, deploy, and repair Notte Functions",
+  "version": "1.4.0",
+  "description": "Drive a real cloud or local browser with Notte \u2014 manage sessions and accounts from the CLI, and build, deploy, and repair Notte Functions",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
   "author": {
     "name": "Notte",
     "url": "https://notte.cc"

--- a/plugins/notte/.mcp.json
+++ b/plugins/notte/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "notte-browser": {
+      "type": "http",
+      "url": "https://api.notte.cc/mcp"
+    },
+    "anything-api": {
+      "type": "http",
+      "url": "https://anything.notte.cc/mcp"
+    }
+  }
+}

--- a/plugins/notte/CHANGELOG.md
+++ b/plugins/notte/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+All notable changes to the `notte` plugin are documented here. The plugin was
+named `notte-cli` before 2026-08-05; entries below 1.4.0 describe it under that
+name.
+
+Versions before 1.4.0 were never tagged; the entries below are reconstructed
+from `git log` so that downstream consumers can tell which skill content
+corresponds to which version. Tag releases as `notte-v<version>` from now
+on so consumers can pin instead of tracking the default branch.
+
+## [1.4.0](https://github.com/nottelabs/notte-skills/compare/notte-v1.3.0...notte-v1.4.0) (2026-08-05)
+
+Packaging and distribution only — no skill content changed.
+
+### Features
+
+* wire the hosted Notte MCP servers into the plugin: `plugins/notte/.mcp.json` declares `notte-browser` (`https://api.notte.cc/mcp`) and `anything-api` (`https://anything.notte.cc/mcp`) as streamable HTTP servers, referenced from `plugin.json` via `"mcpServers": "./.mcp.json"`. Replaces the inert root `mcp.json`, which used the legacy SSE shape, pointed at `http://localhost:8001/sse`, and was referenced by nothing.
+
+### Bug Fixes
+
+* remove the `notte-sdks` marketplace entry and Cursor skills path, which pointed at a directory that does not exist in the repository
+* declare skills explicitly in `plugin.json` (`"skills": "./skills/"`) instead of relying on directory convention
+* add `scripts/validate-plugins.py` and run it in CI on every change under `plugins/**` and the manifests
+
+## [1.3.0](https://github.com/nottelabs/notte-skills/compare/notte-v1.2.0...notte-v1.3.0) (2026-07-29)
+
+### Features
+
+* add provider migration and cost skills ([#20](https://github.com/nottelabs/notte-skills/pull/20)) ([3921ff8](https://github.com/nottelabs/notte-skills/commit/3921ff8)) — adds the `migrate-to-notte` and `compare-to-notte-costs` skills covering Browserbase/Stagehand, Kernel, Anchor Browser, Browser Use Cloud, Steel, Hyperbrowser, and Skyvern
+
+## [1.2.0](https://github.com/nottelabs/notte-skills/compare/notte-v1.1.0...notte-v1.2.0) (2026-06-30)
+
+### Features
+
+* add `notte-functions-forge` and `notte-functions-doctor` skills ([#16](https://github.com/nottelabs/notte-skills/pull/16)) ([b051cff](https://github.com/nottelabs/notte-skills/commit/b051cff))
+
+### Bug Fixes
+
+* **notte-browser:** correct the run-output field ([#17](https://github.com/nottelabs/notte-skills/pull/17)) ([7334a3d](https://github.com/nottelabs/notte-skills/commit/7334a3d))
+
+## [1.1.0](https://github.com/nottelabs/notte-skills/compare/notte-v1.0.0...notte-v1.1.0) (2026-06-05)
+
+Documentation and guidance changes to `notte-browser` that shipped silently
+under the `1.0.0` version pin.
+
+### Features
+
+* consolidate the Notte browser skill ([#4](https://github.com/nottelabs/notte-skills/pull/4)) ([e103e2b](https://github.com/nottelabs/notte-skills/commit/e103e2b))
+* add a Notte docs index pointer ([#5](https://github.com/nottelabs/notte-skills/pull/5)) ([d973fb1](https://github.com/nottelabs/notte-skills/commit/d973fb1))
+* document browser profiles ([#14](https://github.com/nottelabs/notte-skills/pull/14)) ([cd85130](https://github.com/nottelabs/notte-skills/commit/cd85130))
+* add a session `workflow-code` example ([#15](https://github.com/nottelabs/notte-skills/pull/15)) ([3cb9f9e](https://github.com/nottelabs/notte-skills/commit/3cb9f9e))
+
+### Bug Fixes
+
+* emphasize session workflow export for Functions ([#6](https://github.com/nottelabs/notte-skills/pull/6)) ([1eb7542](https://github.com/nottelabs/notte-skills/commit/1eb7542))
+* clarify that Notte Functions are API endpoints ([#7](https://github.com/nottelabs/notte-skills/pull/7)) ([3ee85e1](https://github.com/nottelabs/notte-skills/commit/3ee85e1))
+* document the `only-main-content` scrape tradeoff ([#8](https://github.com/nottelabs/notte-skills/pull/8)) ([04d2a74](https://github.com/nottelabs/notte-skills/commit/04d2a74))
+* document `workflow-code` session id export ([#9](https://github.com/nottelabs/notte-skills/pull/9)) ([3c8b8b8](https://github.com/nottelabs/notte-skills/commit/3c8b8b8))
+* clarify Notte Function endpoint intents ([#11](https://github.com/nottelabs/notte-skills/pull/11)) ([519a0f5](https://github.com/nottelabs/notte-skills/commit/519a0f5))
+* clarify Notte auth login handling ([#12](https://github.com/nottelabs/notte-skills/pull/12)) ([c29bb20](https://github.com/nottelabs/notte-skills/commit/c29bb20))
+
+## 1.0.0 (2026-05-07)
+
+### Features
+
+* restructure the repository as a marketplace plugin ([#1](https://github.com/nottelabs/notte-skills/pull/1)) ([90308d2](https://github.com/nottelabs/notte-skills/commit/90308d2)) — initial release of the `notte-cli` plugin with the `notte-browser` skill

--- a/scripts/validate-plugins.py
+++ b/scripts/validate-plugins.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Validate the Notte skills marketplace manifests and skill packaging.
+
+Runs in CI (.github/workflows/test-skills.yml) and locally:
+
+    python3 scripts/validate-plugins.py
+
+Checks performed:
+  * .claude-plugin/marketplace.json and .cursor-plugin/plugin.json are valid JSON
+  * every plugins/*/.claude-plugin/plugin.json is valid JSON
+  * every path referenced by marketplace.json (plugins[].source) exists on disk
+  * every path referenced by the Cursor manifest (skills, rules, logo) exists
+  * every path referenced by a plugin.json (skills, mcpServers) exists
+  * every SKILL.md has YAML frontmatter with a non-empty name and description
+  * every SKILL.md's name matches the directory that contains it
+
+Stdlib only, no third-party dependencies (including no PyYAML: the frontmatter
+subset used by skills is parsed directly).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+MARKETPLACE = Path(".claude-plugin/marketplace.json")
+CURSOR_MANIFEST = Path(".cursor-plugin/plugin.json")
+
+errors: list[str] = []
+checks = 0
+
+
+def fail(message: str) -> None:
+    errors.append(message)
+
+
+def ok(message: str) -> None:
+    global checks
+    checks += 1
+    print(f"  ok  {message}")
+
+
+def load_json(rel_path: Path) -> dict | None:
+    """Read and parse a JSON manifest, recording an error on failure."""
+    path = REPO_ROOT / rel_path
+    if not path.is_file():
+        fail(f"{rel_path}: file is missing")
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"{rel_path}: invalid JSON ({exc})")
+        return None
+    ok(f"{rel_path} is valid JSON")
+    return data
+
+
+def is_remote(value: str) -> bool:
+    return value.startswith(("http://", "https://", "git@", "github:"))
+
+
+def check_path(rel_path: Path, field: str, value: object) -> None:
+    """Assert that a manifest-declared relative path resolves on disk."""
+    if not isinstance(value, str):
+        fail(f"{rel_path}: {field} must be a string, got {type(value).__name__}")
+        return
+    if is_remote(value):
+        ok(f"{rel_path}: {field} -> {value} (remote, not checked)")
+        return
+    # removeprefix, not lstrip: lstrip("./") would eat the leading dot of a
+    # dotfile path such as "./.mcp.json".
+    target = (REPO_ROOT / value.removeprefix("./")).resolve()
+    try:
+        target.relative_to(REPO_ROOT)
+    except ValueError:
+        fail(f"{rel_path}: {field} -> {value} escapes the repository root")
+        return
+    if not target.exists():
+        fail(f"{rel_path}: {field} -> {value} does not exist on disk")
+        return
+    ok(f"{rel_path}: {field} -> {value}")
+
+
+def check_paths(rel_path: Path, field: str, value: object) -> None:
+    """Same as check_path but tolerates a list of paths."""
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            check_path(rel_path, f"{field}[{index}]", item)
+    else:
+        check_path(rel_path, field, value)
+
+
+def parse_frontmatter(text: str) -> dict[str, str] | None:
+    """Parse the top-level scalar keys of a YAML frontmatter block.
+
+    Supports plain scalars (`name: value`) and folded/literal block scalars
+    (`description: >` followed by an indented body), which is the full range
+    used by SKILL.md frontmatter in this repo.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    try:
+        end = next(i for i, line in enumerate(lines[1:], start=1) if line.strip() == "---")
+    except StopIteration:
+        return None
+
+    fields: dict[str, str] = {}
+    key: str | None = None
+    block: list[str] = []
+
+    def flush() -> None:
+        if key is not None:
+            fields[key] = " ".join(part.strip() for part in block).strip()
+
+    for line in lines[1:end]:
+        if line.strip() and not line[0].isspace() and ":" in line:
+            flush()
+            key, _, value = line.partition(":")
+            key = key.strip()
+            value = value.strip()
+            block = [] if value in (">", "|", ">-", "|-", "") else [value]
+        elif key is not None:
+            block.append(line)
+    flush()
+    return fields
+
+
+def validate_marketplace() -> None:
+    data = load_json(MARKETPLACE)
+    if data is None:
+        return
+    plugins = data.get("plugins")
+    if not isinstance(plugins, list) or not plugins:
+        fail(f"{MARKETPLACE}: plugins must be a non-empty array")
+        return
+    for entry in plugins:
+        if not isinstance(entry, dict):
+            fail(f"{MARKETPLACE}: every plugins[] entry must be an object")
+            continue
+        name = entry.get("name") or "<unnamed>"
+        if not entry.get("name"):
+            fail(f"{MARKETPLACE}: a plugins[] entry has no name")
+        if not entry.get("description"):
+            fail(f"{MARKETPLACE}: plugin '{name}' has no description")
+        source = entry.get("source")
+        if source is None:
+            fail(f"{MARKETPLACE}: plugin '{name}' has no source")
+            continue
+        check_path(MARKETPLACE, f"plugins['{name}'].source", source)
+
+
+def validate_cursor_manifest() -> None:
+    data = load_json(CURSOR_MANIFEST)
+    if data is None:
+        return
+    for field in ("skills", "rules", "logo"):
+        if field in data:
+            check_paths(CURSOR_MANIFEST, field, data[field])
+
+
+def validate_plugin_manifests() -> None:
+    manifests = sorted((REPO_ROOT / "plugins").glob("*/.claude-plugin/plugin.json"))
+    if not manifests:
+        fail("plugins/: no plugins/*/.claude-plugin/plugin.json found")
+        return
+    for path in manifests:
+        rel = path.relative_to(REPO_ROOT)
+        data = load_json(rel)
+        if data is None:
+            continue
+        for field in ("name", "version", "description"):
+            if not data.get(field):
+                fail(f"{rel}: missing or empty '{field}'")
+        plugin_dir = path.parent.parent
+        if data.get("name") and data["name"] != plugin_dir.name:
+            fail(
+                f"{rel}: name '{data['name']}' does not match "
+                f"directory '{plugin_dir.name}'"
+            )
+        for field in ("skills", "mcpServers", "hooks", "commands", "agents"):
+            if field in data:
+                value = data[field]
+                if isinstance(value, list):
+                    for index, item in enumerate(value):
+                        check_path(rel, f"{field}[{index}]", _rel_to_root(plugin_dir, item))
+                else:
+                    check_path(rel, field, _rel_to_root(plugin_dir, value))
+
+
+def _rel_to_root(plugin_dir: Path, value: object) -> object:
+    """Rewrite a plugin-relative path into a repo-root-relative one."""
+    if not isinstance(value, str) or is_remote(value):
+        return value
+    prefix = plugin_dir.relative_to(REPO_ROOT)
+    return f"./{prefix}/{value.removeprefix('./')}"
+
+
+def validate_skills() -> None:
+    skill_files = sorted((REPO_ROOT / "plugins").rglob("SKILL.md"))
+    if not skill_files:
+        fail("plugins/: no SKILL.md files found")
+        return
+    for path in skill_files:
+        rel = path.relative_to(REPO_ROOT)
+        fields = parse_frontmatter(path.read_text(encoding="utf-8"))
+        if fields is None:
+            fail(f"{rel}: missing or unterminated YAML frontmatter block")
+            continue
+        name = fields.get("name", "").strip()
+        description = fields.get("description", "").strip()
+        if not name:
+            fail(f"{rel}: frontmatter has no non-empty 'name'")
+        if not description:
+            fail(f"{rel}: frontmatter has no non-empty 'description'")
+        directory = path.parent.name
+        if name and name != directory:
+            fail(f"{rel}: frontmatter name '{name}' does not match directory '{directory}'")
+        if name and description and name == directory:
+            ok(f"{rel}: name '{name}' matches directory, description present")
+
+
+def main() -> int:
+    print(f"Validating {REPO_ROOT}\n")
+    validate_marketplace()
+    validate_cursor_manifest()
+    validate_plugin_manifests()
+    validate_skills()
+
+    print()
+    if errors:
+        print(f"FAILED: {len(errors)} problem(s) found after {checks} passing check(s):\n")
+        for error in errors:
+            print(f"  error  {error}")
+        return 1
+    print(f"PASSED: {checks} check(s), no problems found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Packaging and distribution fixes. **No skill content was modified** (no `SKILL.md` bodies, `references/`, or `templates/`), and nothing was renamed or moved — the `plugins/notte-cli` → `plugins/notte` rename is a separate PR.

## Bugs fixed

### 1. `notte-sdks` was declared but does not exist
`.claude-plugin/marketplace.json` advertised a plugin `notte-sdks` with `"source": "./plugins/notte-sdks"`, and `.cursor-plugin/plugin.json` listed `"./plugins/notte-sdks/skills/"`. That directory is not in the repo, so the marketplace entry was broken for anyone installing from it. Both references are removed.

**This entry should be re-added when the SDK plugin actually exists** — it was deliberately not scaffolded as an empty plugin here.

### 2. `plugin.json` did not declare its skills
`plugins/notte-cli/.claude-plugin/plugin.json` relied on directory convention. It now declares `"skills": "./skills/"` explicitly, matching the form the official Supabase plugin uses.

### 3. Root `mcp.json` was inert and pointed at localhost
The old file was `mcp.json` (not the `.mcp.json` dotfile), was referenced by nothing, used the legacy SSE shape, and pointed at `http://localhost:8001/sse`.

It is replaced by `plugins/notte-cli/.mcp.json`, wired from `plugin.json` via `"mcpServers": "./.mcp.json"` (the pattern Supabase uses), declaring both hosted endpoints as modern streamable HTTP servers:

| Server | URL |
|---|---|
| `notte-browser` | `https://api.notte.cc/mcp` |
| `anything-api` | `https://anything.notte.cc/mcp` |

Both were probed live: `anything.notte.cc/mcp` answers `initialize` with `200`; `api.notte.cc/mcp` returns `401` with a `WWW-Authenticate: Bearer ... resource_metadata=https://api.notte.cc/.well-known/oauth-protected-resource/mcp/` header, i.e. it advertises OAuth and MCP clients will run the auth flow themselves. No static token or `headers` block is therefore needed in the config.

### 4. No versioning discipline
The plugin was pinned at `1.0.0` since 2026-05-07 while skill content changed across 13 commits, with no tags and no changelog — one downstream consumer (`nottelabs/anything-api`, which `degit`s this skill off the default branch) has been broken twice by silent changes.

- version bumped to **1.4.0** in both `plugins/notte-cli/.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` (they had drifted to separate meanings of "1.0.0"; they now move together)
- added `plugins/notte-cli/CHANGELOG.md` in the style the Supabase skills use, reconstructing from `git log` the releases that shipped silently under the `1.0.0` pin: `1.1.0` (browser skill consolidation + docs, #4–#15), `1.2.0` (`notte-functions-forge` / `notte-functions-doctor`, #16–#17), `1.3.0` (`migrate-to-notte` / `compare-to-notte-costs`, #20), `1.4.0` (this PR)

**Left for a maintainer:** no git tag was cut from this branch. Please tag `notte-cli-v1.4.0` on merge, so consumers can pin instead of tracking the default branch.

### 5. CI validated nothing that matters
`.github/workflows/test-skills.yml` only triggered on `plugins/**/templates/**` and only ran `bash -n` + shellcheck on `.sh` files. It could not have caught bug #1, and did not catch the earlier incident where a skill path moved and silently 404'd for ~18 days.

Added `scripts/validate-plugins.py` (Python 3 stdlib only — no PyYAML, the frontmatter subset is parsed directly) and a `validate-manifests` job that runs on all changes under `plugins/**`, `rules/**`, `assets/**`, and both manifests. It checks:

- both manifests, and every `plugins/*/.claude-plugin/plugin.json`, are valid JSON
- every `plugins[].source` in `marketplace.json` resolves on disk
- every `skills` / `rules` / `logo` path in the Cursor manifest resolves on disk
- every `skills` / `mcpServers` / `hooks` / `commands` / `agents` path in a `plugin.json` resolves on disk (so a dangling MCP reference cannot ship the way the `notte-sdks` one did)
- every `SKILL.md` has frontmatter with a non-empty `name` and `description`
- every `SKILL.md`'s `name` matches its containing directory

It is runnable locally with `python3 scripts/validate-plugins.py`. The existing shellcheck job is kept unchanged.

## Validator verification

Run against this branch — **passes**, 14 checks:

```
PASSED: 14 check(s), no problems found.
```

Each check was also confirmed to actually fail when the corresponding bug is reintroduced (exit code 1 in every case):

| Injected fault | Result |
|---|---|
| Re-add the `notte-sdks` entry + Cursor skills path | `error  .claude-plugin/marketplace.json: plugins['notte-sdks'].source -> ./plugins/notte-sdks does not exist on disk` and `error  .cursor-plugin/plugin.json: skills[1] -> ./plugins/notte-sdks/skills/ does not exist on disk` |
| Rename a `SKILL.md` `name` away from its directory | `error  ... frontmatter name 'notte-browser-renamed' does not match directory 'notte-browser'` |
| Empty a `description` | `error  ... frontmatter has no non-empty 'description'` |
| Corrupt `.cursor-plugin/plugin.json` | `error  .cursor-plugin/plugin.json: invalid JSON (...)` |
| Point `plugin.json` `skills` at a missing dir | `error  ... skills -> ./plugins/notte-cli/skillz/ does not exist on disk` |
| Point `plugin.json` `mcpServers` at a missing file | `error  ... mcpServers -> ./plugins/notte-cli/.mcp-missing.json does not exist on disk` |

## Deliberately not done

- **No `notte-sdks` scaffold.** The marketplace entry is removed rather than backed by an empty plugin; re-add it when the SDK plugin lands.
- **No git tag.** See above — tag `notte-cli-v1.4.0` on merge.
- **No `mcpServers` key added to `.cursor-plugin/plugin.json`.** Cursor points at a non-dotfile path (`./agents/cursor/mcp.json` in the Supabase reference) and the correct location for this repo's layout is a maintainer call, especially with the `plugins/notte-cli` → `plugins/notte` rename in flight. The Claude side is wired; Cursor MCP is still unwired, as it was before.
- **No directory renames or moves**, and no skill content edits, per the in-flight PRs on `notte-browser` docs and the plugin rename.
- **README's "Available skills" table is stale** — it lists 3 skills and omits `migrate-to-notte` and `compare-to-notte-costs` (added in #20). Not fixed here to avoid colliding with the docs PR; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)