### PR TITLE
ci: open a pin-bump PR on anything-api for every skill change

### DIFF
--- a/.github/workflows/bump-anything-api.yml
+++ b/.github/workflows/bump-anything-api.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out notte-skills (needed by the bump + changelog steps)
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: notte-skills
           fetch-depth: 0
 
       - name: Check out anything-api
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: nottelabs/anything-api
           # Needs contents:write + pull-requests:write on nottelabs/anything-api.
@@ -118,7 +118,7 @@ jobs:
 
       - name: Open or update the PR
         if: steps.bump.outputs.already == 'false'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           path: anything-api
           token: ${{ secrets.ANYTHING_API_BUMP_TOKEN }}

--- a/.github/workflows/bump-anything-api.yml
+++ b/.github/workflows/bump-anything-api.yml
@@ -21,6 +21,12 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out notte-skills (needed by the bump + changelog steps)
+        uses: actions/checkout@v4
+        with:
+          path: notte-skills
+          fetch-depth: 0
+
       - name: Check out anything-api
         uses: actions/checkout@v4
         with:
@@ -28,12 +34,6 @@ jobs:
           # Needs contents:write + pull-requests:write on nottelabs/anything-api.
           token: ${{ secrets.ANYTHING_API_BUMP_TOKEN }}
           path: anything-api
-
-      - name: Check out notte-skills (for the changelog range)
-        uses: actions/checkout@v4
-        with:
-          path: notte-skills
-          fetch-depth: 0
 
       - name: Bump the pin
         id: bump
@@ -55,6 +55,17 @@ jobs:
             echo "already=true" >> "$GITHUB_OUTPUT"
             echo "Pin already at $NEW_REF, nothing to do."
             exit 0
+          fi
+
+          # The pinned subdir must still exist at the new ref. It is human-owned
+          # (a rename is a reviewed change, not something CI should guess), so
+          # if upstream moved it we open nothing and fail loudly -- otherwise we
+          # would file a green-looking PR that breaks the snapshot build.
+          SUBDIR=$(jq -r .subdir "$PIN_FILE")
+          if ! git -C "$GITHUB_WORKSPACE/notte-skills" cat-file -e "$NEW_REF:$SUBDIR" 2>/dev/null; then
+            echo "::error::'$SUBDIR' does not exist at $NEW_REF in ${{ github.repository }}."
+            echo "::error::The skill path moved upstream. Update .subdir in $PIN_FILE by hand, in the same PR as the ref bump."
+            exit 1
           fi
 
           # Rewrite only .ref — repo/subdir are human-owned and must not be

--- a/.github/workflows/bump-anything-api.yml
+++ b/.github/workflows/bump-anything-api.yml
@@ -1,0 +1,123 @@
+name: Bump anything-api skill pin
+
+# The notte-browser skill is consumed by nottelabs/anything-api, which installs
+# it into its agent sandbox snapshot. That consumer pins an exact commit of this
+# repo in notte-skill.pin.json, so changes here do NOT reach its production
+# agent until the pin moves. This workflow moves it: every push to main opens
+# (or updates) a PR there bumping the pin, so an upstream doc change lands as a
+# reviewable diff downstream instead of silently, or never.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/**'
+  workflow_dispatch:
+
+concurrency:
+  group: bump-anything-api
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out anything-api
+        uses: actions/checkout@v4
+        with:
+          repository: nottelabs/anything-api
+          # Needs contents:write + pull-requests:write on nottelabs/anything-api.
+          token: ${{ secrets.ANYTHING_API_BUMP_TOKEN }}
+          path: anything-api
+
+      - name: Check out notte-skills (for the changelog range)
+        uses: actions/checkout@v4
+        with:
+          path: notte-skills
+          fetch-depth: 0
+
+      - name: Bump the pin
+        id: bump
+        working-directory: anything-api
+        run: |
+          set -euo pipefail
+          PIN_FILE=notte-skill.pin.json
+          if [ ! -f "$PIN_FILE" ]; then
+            echo "::error::$PIN_FILE not found in anything-api — has the pin moved or been removed?"
+            exit 1
+          fi
+
+          OLD_REF=$(jq -r .ref "$PIN_FILE")
+          NEW_REF=${{ github.sha }}
+          echo "old=$OLD_REF" >> "$GITHUB_OUTPUT"
+          echo "new=$NEW_REF" >> "$GITHUB_OUTPUT"
+
+          if [ "$OLD_REF" = "$NEW_REF" ]; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+            echo "Pin already at $NEW_REF, nothing to do."
+            exit 0
+          fi
+
+          # Rewrite only .ref — repo/subdir are human-owned and must not be
+          # clobbered by automation (a rename downstream is a reviewed change).
+          jq --arg ref "$NEW_REF" '.ref = $ref' "$PIN_FILE" > "$PIN_FILE.tmp"
+          mv "$PIN_FILE.tmp" "$PIN_FILE"
+          echo "already=false" >> "$GITHUB_OUTPUT"
+
+      - name: Build the changelog for this bump
+        if: steps.bump.outputs.already == 'false'
+        id: log
+        working-directory: notte-skills
+        run: |
+          set -euo pipefail
+          OLD="${{ steps.bump.outputs.old }}"
+          {
+            echo 'body<<PRBODY'
+            echo "Bumps the pinned \`notte-browser\` skill in \`notte-skill.pin.json\`."
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| from | \`${OLD}\` |"
+            echo "| to | \`${{ steps.bump.outputs.new }}\` |"
+            echo
+            echo "### Upstream commits"
+            echo
+            # If the old ref is unreachable (force-push, or a first-ever bump),
+            # fall back to naming the head commit rather than failing the job.
+            if git cat-file -e "${OLD}^{commit}" 2>/dev/null; then
+              git log --no-merges --pretty='- %h %s' "${OLD}..${{ github.sha }}" -- plugins/ || true
+            else
+              echo "- (previous ref \`${OLD}\` not reachable; showing head only)"
+              git log -1 --pretty='- %h %s'
+            fi
+            echo
+            echo "### Review focus"
+            echo
+            echo "Skill guidance shapes how the build agent writes Notte Functions."
+            echo "Read the diff for changes to **implementation-path guidance** —"
+            echo "anything that shifts the agent between reconstructing an HTTP API,"
+            echo "parsing HTML deterministically, and calling \`session.scrape()\`."
+            echo "A wording change there moves production latency and cost."
+            echo
+            echo "Merging this PR does not deploy the skill. It reaches production on"
+            echo "the next snapshot rebuild."
+            echo
+            echo "Opened automatically by \`bump-anything-api.yml\` in nottelabs/notte-skills."
+            echo 'PRBODY'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the PR
+        if: steps.bump.outputs.already == 'false'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          path: anything-api
+          token: ${{ secrets.ANYTHING_API_BUMP_TOKEN }}
+          branch: chore/bump-notte-skill-pin
+          base: main
+          commit-message: |
+            chore: bump notte-browser skill pin to ${{ steps.bump.outputs.new }}
+
+            Co-Authored-By: nottelabs/notte-skills CI <noreply@notte.cc>
+          title: 'chore: bump notte-browser skill pin'
+          body: ${{ steps.log.outputs.body }}
+          labels: dependencies, notte-skills
+          delete-branch: true


### PR DESCRIPTION
Companion to nottelabs/anything-api#318. **Needs a secret before it works — see below.**

## Why

`nottelabs/anything-api` installs `notte-browser` into its agent sandbox snapshot, and has been fetching this repo's **default branch**. So a wording change here reached its production agent on whatever unrelated change next triggered a snapshot rebuild — unreviewed, with nothing recording which version shipped.

That is not hypothetical. The `workflow-code`-first rule added in `1eb7542` shifted that agent from reconstructing HTTP APIs to browser+LLM scraping. A recent prod run spent **11.2s of 15.5s in a single Gemini call** transcribing Hacker News' front page — a page with rigid HTML and a public JSON API. Nobody reviewed that change downstream, because there was nothing to review.

anything-api#318 pins an exact commit. That makes delivery reviewable, but it also means changes here stop arriving **at all** unless something moves the pin. This workflow is that something.

## What it does

On every push to `main` touching `plugins/**`, it opens or updates a PR on anything-api bumping `.ref` in `notte-skill.pin.json`, with:

- old → new SHA
- the list of upstream commits in the range
- a review prompt pointing at implementation-path guidance, since that is what moves production latency and cost

Only `.ref` is rewritten. `repo` and `subdir` stay human-owned, so the rename in #23 stays a reviewed downstream change rather than something CI can clobber.

## Setup required

Create a **fine-grained PAT** scoped to `nottelabs/anything-api` with:

- `Contents: read and write`
- `Pull requests: read and write`

Store it in this repo as `ANYTHING_API_BUMP_TOKEN`. Until then the job fails at checkout — it does not fail silently.

## Verification

YAML parses. `jq --arg ref ... '.ref = $ref'` simulated against the real pin file: rewrites `ref`, leaves `repo`, `subdir` and `_comment` intact.

Two failure paths handled explicitly: pin file missing downstream (hard error naming the file, rather than a confusing jq failure), and an unreachable previous ref after a force-push (falls back to naming the head commit instead of failing the job).

`concurrency` prevents overlapping pushes racing on the same branch; `delete-branch` keeps it tidy.

## Ordering

Land anything-api#318 first — this workflow expects `notte-skill.pin.json` to exist there and errors clearly if it does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)