### PR TITLE
ci: verify plugin installation on Claude Code, Codex, and Cursor

### DIFF
--- a/.github/workflows/test-skills.yml
+++ b/.github/workflows/test-skills.yml
@@ -57,13 +57,19 @@ jobs:
           done
 
       - name: Lint with shellcheck
-        uses: ludeeus/action-shellcheck@master
+        # Pinned: @master is a mutable branch, so an upstream push would
+        # change what runs in CI without a commit here. SHA is master as of
+        # 2024-06-20, the revision this repo has been running.
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca
         with:
           scandir: './plugins'
           severity: warning
 
       - name: Lint repo scripts with shellcheck
-        uses: ludeeus/action-shellcheck@master
+        # Pinned: @master is a mutable branch, so an upstream push would
+        # change what runs in CI without a commit here. SHA is master as of
+        # 2024-06-20, the revision this repo has been running.
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca
         with:
           scandir: './scripts'
           severity: warning

--- a/.github/workflows/test-skills.yml
+++ b/.github/workflows/test-skills.yml
@@ -10,6 +10,7 @@ on:
       - '.cursor-plugin/**'
       - '.agents/**'
       - 'scripts/*.py'
+      - 'scripts/*.sh'
       - '.github/workflows/test-skills.yml'
   pull_request:
     paths:
@@ -20,6 +21,7 @@ on:
       - '.cursor-plugin/**'
       - '.agents/**'
       - 'scripts/*.py'
+      - 'scripts/*.sh'
       - '.github/workflows/test-skills.yml'
 
 jobs:
@@ -58,4 +60,10 @@ jobs:
         uses: ludeeus/action-shellcheck@master
         with:
           scandir: './plugins'
+          severity: warning
+
+      - name: Lint repo scripts with shellcheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: './scripts'
           severity: warning

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -89,11 +89,26 @@ jobs:
       # The Cursor CLI has no offline install-and-inspect surface, so the live
       # check boots a real agent session and costs model tokens. Keep it off the
       # PR path: pull requests get the manifest resolution check only.
-      - name: Install cursor-agent
+      #
+      # Deliberately not `curl https://cursor.com/install | bash`: the next step
+      # hands this binary a real API key, so it must not be a mutable remote
+      # artifact. The installer is a generated script that pins one version and
+      # downloads it from the URL below, so fetching that URL directly and
+      # checking its digest gets the same binary without trusting the script.
+      # Bump VERSION and SHA256 together; see the workflow README note.
+      - name: Install cursor-agent (pinned and checksum-verified)
         if: github.event_name != 'pull_request'
+        env:
+          CURSOR_AGENT_VERSION: 2026.07.23-e383d2b
+          CURSOR_AGENT_SHA256: 702ad595213bee5df0268be9f80a19f29fcceaa2a42fc55e39f2b5199051f0c4
         run: |
-          curl https://cursor.com/install -fsS | bash
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
+          url="https://downloads.cursor.com/lab/${CURSOR_AGENT_VERSION}/linux/x64/agent-cli-package.tar.gz"
+          curl -fsSL "$url" -o /tmp/cursor-agent.tar.gz
+          echo "${CURSOR_AGENT_SHA256}  /tmp/cursor-agent.tar.gz" | sha256sum -c -
+          mkdir -p "$HOME/.local/cursor-agent"
+          tar --strip-components=1 -xzf /tmp/cursor-agent.tar.gz -C "$HOME/.local/cursor-agent"
+          echo "$HOME/.local/cursor-agent" >> "$GITHUB_PATH"
 
       # Also runnable locally: scripts/verify-install-cursor.sh
       - name: Verify skill and MCP server

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -110,8 +110,19 @@ jobs:
           tar --strip-components=1 -xzf /tmp/cursor-agent.tar.gz -C "$HOME/.local/cursor-agent"
           echo "$HOME/.local/cursor-agent" >> "$GITHUB_PATH"
 
+      # Split from the live probe on purpose. As one step, a pull request run
+      # showed a green "Cursor" check for what was only a manifest check, which
+      # reads as more coverage than it is. Two steps make the UI say which ran.
       # Also runnable locally: scripts/verify-install-cursor.sh
-      - name: Verify skill and MCP server
+      - name: Resolve the Cursor manifest
+        run: scripts/verify-install-cursor.sh
+
+      # CURSOR_REQUIRE_LIVE turns a missing secret into a red job rather than a
+      # pass for a check that never ran. If this fails with "CURSOR_API_KEY is
+      # unset", add the secret - do not relax the guard.
+      - name: Probe a live cursor-agent session
+        if: github.event_name != 'pull_request'
         env:
-          CURSOR_API_KEY: ${{ github.event_name != 'pull_request' && secrets.CURSOR_API_KEY || '' }}
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          CURSOR_REQUIRE_LIVE: '1'
         run: scripts/verify-install-cursor.sh

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -1,0 +1,102 @@
+name: Verify Install
+
+# Installs this repo's plugins with the real client CLIs and asserts that the
+# notte-browser skill and the https://anything.notte.cc/mcp MCP server are
+# actually loaded, and that Codex exposes our install-surface metadata.
+# validate-plugins.py checks that the manifests are well formed; this checks
+# that the clients agree with our reading of them.
+#
+# The weekly schedule matters as much as the PR runs: these jobs install the
+# CLIs at @latest, so a breaking change on the client side shows up here even
+# when nothing in this repo has changed.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'plugins/**'
+      - 'rules/**'
+      - '.claude-plugin/**'
+      - '.cursor-plugin/**'
+      - '.agents/**'
+      - 'scripts/verify-install-*.sh'
+      - 'scripts/verify-codex-app-server.py'
+      - '.github/workflows/verify-install.yml'
+  pull_request:
+    paths:
+      - 'plugins/**'
+      - 'rules/**'
+      - '.claude-plugin/**'
+      - '.cursor-plugin/**'
+      - '.agents/**'
+      - 'scripts/verify-install-*.sh'
+      - 'scripts/verify-codex-app-server.py'
+      - '.github/workflows/verify-install.yml'
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-install-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  claude-code:
+    name: Claude Code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      # Installs from the checkout, so a PR is verified before it lands.
+      # Also runnable locally: scripts/verify-install-claude.sh
+      - name: Install plugins and verify skill and MCP server
+        run: scripts/verify-install-claude.sh
+
+  codex:
+    name: Codex
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install Codex
+        run: npm install -g @openai/codex
+
+      # Also runnable locally: scripts/verify-install-codex.sh
+      - name: Install plugins and verify skill and MCP server
+        run: scripts/verify-install-codex.sh
+
+  cursor:
+    name: Cursor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # The Cursor CLI has no offline install-and-inspect surface, so the live
+      # check boots a real agent session and costs model tokens. Keep it off the
+      # PR path: pull requests get the manifest resolution check only.
+      - name: Install cursor-agent
+        if: github.event_name != 'pull_request'
+        run: |
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # Also runnable locally: scripts/verify-install-cursor.sh
+      - name: Verify skill and MCP server
+        env:
+          CURSOR_API_KEY: ${{ github.event_name != 'pull_request' && secrets.CURSOR_API_KEY || '' }}
+        run: scripts/verify-install-cursor.sh

--- a/scripts/verify-codex-app-server.py
+++ b/scripts/verify-codex-app-server.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Assert that Codex's app-server API exposes our plugin install-surface metadata.
+
+Called by scripts/verify-install-codex.sh once the plugins are installed into a
+throwaway CODEX_HOME; can also be run directly against an existing one:
+
+    CODEX_HOME=... python3 scripts/verify-codex-app-server.py [repo-root]
+
+Why a separate surface: `codex plugin list --json` is a reduced projection that
+omits `interface` entirely. The Codex /plugins browser and the ChatGPT desktop
+app read the app-server JSON-RPC API instead, where marketplaces, plugins, and
+individual skills each carry their own `interface` block. Everything the
+.codex-plugin manifests and agents/openai.yaml files contribute is invisible to
+the CLI, so asserting on the CLI alone would let all of it silently regress -
+which is exactly how three of four skills once shipped with no display metadata.
+
+validate-plugins.py checks those files exist and parse; this checks Codex agrees.
+
+Stdlib only. No OpenAI credentials needed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+
+MARKETPLACE = "notte"
+PLUGIN_ID = "notte@notte"
+# The metadata each surface must carry. Presence, not exact values: this guards
+# against the blocks being dropped, not against copy edits.
+PLUGIN_INTERFACE_FIELDS = ("displayName", "shortDescription", "category")
+SKILL_INTERFACE_FIELDS = ("displayName", "shortDescription", "defaultPrompt")
+REPLY_TIMEOUT_SEC = 60
+
+errors: list[str] = []
+
+
+def fail(message: str) -> None:
+    errors.append(message)
+    print(f"  FAIL  {message}", file=sys.stderr)
+
+
+def ok(message: str) -> None:
+    print(f"  ok    {message}")
+
+
+class AppServer:
+    """Minimal JSON-RPC client for `codex app-server` over stdio."""
+
+    def __init__(self, cwd: str) -> None:
+        self.proc = subprocess.Popen(
+            ["codex", "app-server"],
+            cwd=cwd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            bufsize=1,
+        )
+        self.lines: queue.Queue[str] = queue.Queue()
+        # A reader thread keeps a hung or silent server from blocking CI forever.
+        threading.Thread(target=self._pump, daemon=True).start()
+        self.next_id = 0
+
+    def _pump(self) -> None:
+        assert self.proc.stdout is not None
+        for line in self.proc.stdout:
+            self.lines.put(line)
+        self.lines.put("")
+
+    def call(self, method: str, params: dict) -> dict:
+        self.next_id += 1
+        request_id = self.next_id
+        self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+        while True:
+            try:
+                line = self.lines.get(timeout=REPLY_TIMEOUT_SEC)
+            except queue.Empty:
+                raise SystemExit(f"  FAIL  codex app-server did not answer {method} in time")
+            if not line:
+                raise SystemExit(f"  FAIL  codex app-server exited before answering {method}")
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # progress notifications and other non-JSON chatter
+            if message.get("id") != request_id:
+                continue
+            if "error" in message:
+                raise SystemExit(f"  FAIL  {method} failed: {json.dumps(message['error'])}")
+            return message.get("result") or {}
+
+    def _send(self, payload: dict) -> None:
+        assert self.proc.stdin is not None
+        self.proc.stdin.write(json.dumps(payload) + "\n")
+        self.proc.stdin.flush()
+
+    def initialize(self) -> None:
+        self.call("initialize", {"clientInfo": {"name": "notte-skills-ci",
+                                                "title": "notte-skills CI",
+                                                "version": "1.0.0"}})
+        self._send({"jsonrpc": "2.0", "method": "initialized"})
+
+    def close(self) -> None:
+        self.proc.terminate()
+
+
+def check_interface(label: str, interface: object, fields: tuple[str, ...]) -> None:
+    if not isinstance(interface, dict) or not interface:
+        fail(f"{label} has no interface metadata (Codex would render it bare)")
+        return
+    missing = [field for field in fields if not interface.get(field)]
+    if missing:
+        fail(f"{label} interface is missing {', '.join(missing)}")
+        return
+    ok(f"{label} exposes {', '.join(fields)}")
+
+
+def validate_plugins(server: AppServer, repo_root: str) -> None:
+    result = server.call("plugin/list", {"cwds": [repo_root]})
+    marketplaces = [m for m in result.get("marketplaces", []) if m.get("name") == MARKETPLACE]
+    if not marketplaces:
+        fail(f"app-server sees no '{MARKETPLACE}' marketplace")
+        return
+    marketplace = marketplaces[0]
+    ok(f"marketplace '{MARKETPLACE}' resolved from {marketplace.get('path')}")
+
+    check_interface(f"marketplace '{MARKETPLACE}'", marketplace.get("interface"), ("displayName",))
+
+    plugins = {p.get("id"): p for p in marketplace.get("plugins", [])}
+    plugin = plugins.get(PLUGIN_ID)
+    if plugin is None:
+        fail(f"app-server does not list {PLUGIN_ID} (saw: {', '.join(sorted(plugins)) or 'none'})")
+        return
+    check_interface(PLUGIN_ID, plugin.get("interface"), PLUGIN_INTERFACE_FIELDS)
+    if not plugin.get("keywords"):
+        fail(f"{PLUGIN_ID} exposes no keywords, so it will not surface in search")
+    else:
+        ok(f"{PLUGIN_ID} exposes {len(plugin['keywords'])} keywords")
+
+
+def validate_skills(server: AppServer, repo_root: str) -> None:
+    result = server.call("skills/list", {"cwds": [repo_root]})
+    skills = [s for group in result.get("data", []) for s in group.get("skills", [])]
+    ours = {s["name"]: s for s in skills if s.get("name", "").startswith(("notte:", "notte-migrate:"))}
+    if not ours:
+        fail("app-server exposes none of our skills")
+        return
+
+    # Every skill we ship, not just a sampled one: the failure this guards against
+    # is a new skill landing without an agents/openai.yaml, which is invisible
+    # until someone opens the plugin browser.
+    for name in sorted(ours):
+        check_interface(f"skill {name}", ours[name].get("interface"), SKILL_INTERFACE_FIELDS)
+
+
+def main() -> int:
+    repo_root = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
+    if not os.environ.get("CODEX_HOME"):
+        print("  FAIL  CODEX_HOME is unset; refusing to touch a real Codex install",
+              file=sys.stderr)
+        return 1
+
+    print(f"Probing the codex app-server API against {repo_root}")
+    server = AppServer(repo_root)
+    try:
+        server.initialize()
+        validate_plugins(server, repo_root)
+        validate_skills(server, repo_root)
+    finally:
+        server.close()
+
+    print()
+    if errors:
+        print(f"FAILED: {len(errors)} problem(s) on the Codex app-server surface.",
+              file=sys.stderr)
+        return 1
+    print("PASSED: Codex exposes our install-surface metadata.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-codex-app-server.py
+++ b/scripts/verify-codex-app-server.py
@@ -27,6 +27,7 @@ import queue
 import subprocess
 import sys
 import threading
+from pathlib import Path
 
 MARKETPLACE = "notte"
 PLUGIN_ID = "notte@notte"
@@ -142,19 +143,49 @@ def validate_plugins(server: AppServer, repo_root: str) -> None:
         ok(f"{PLUGIN_ID} exposes {len(plugin['keywords'])} keywords")
 
 
+def shipped_skills(repo_root: str) -> set[str]:
+    """Every skill this repo ships, named the way Codex namespaces them.
+
+    Derived from disk rather than from the API response: checking only the
+    skills the API happened to return would pass while a skill was silently
+    missing, which is the more serious failure of the two.
+    """
+    plugins = Path(repo_root) / "plugins"
+    return {
+        f"{plugin.name}:{skill.parent.name}"
+        for plugin in plugins.iterdir()
+        if plugin.is_dir()
+        for skill in plugin.glob("skills/*/SKILL.md")
+    }
+
+
 def validate_skills(server: AppServer, repo_root: str) -> None:
-    result = server.call("skills/list", {"cwds": [repo_root]})
-    skills = [s for group in result.get("data", []) for s in group.get("skills", [])]
-    ours = {s["name"]: s for s in skills if s.get("name", "").startswith(("notte:", "notte-migrate:"))}
-    if not ours:
-        fail("app-server exposes none of our skills")
+    expected = shipped_skills(repo_root)
+    if not expected:
+        fail(f"found no plugins/*/skills/*/SKILL.md under {repo_root} to check against")
         return
 
-    # Every skill we ship, not just a sampled one: the failure this guards against
-    # is a new skill landing without an agents/openai.yaml, which is invisible
-    # until someone opens the plugin browser.
-    for name in sorted(ours):
-        check_interface(f"skill {name}", ours[name].get("interface"), SKILL_INTERFACE_FIELDS)
+    result = server.call("skills/list", {"cwds": [repo_root]})
+    returned = {
+        s["name"]: s
+        for group in result.get("data", [])
+        for s in group.get("skills", [])
+        if s.get("name")
+    }
+
+    for name in sorted(expected - returned.keys()):
+        fail(f"app-server does not expose skill {name}, which this repo ships")
+    present = expected & returned.keys()
+    if present:
+        ok(f"app-server exposes all {len(present)}/{len(expected)} shipped skills"
+           if present == expected else
+           f"app-server exposes {len(present)}/{len(expected)} shipped skills")
+
+    # Checked per skill, because the failure this guards against is one new skill
+    # landing without an agents/openai.yaml - invisible until someone opens the
+    # plugin browser.
+    for name in sorted(present):
+        check_interface(f"skill {name}", returned[name].get("interface"), SKILL_INTERFACE_FIELDS)
 
 
 def main() -> int:

--- a/scripts/verify-install-claude.sh
+++ b/scripts/verify-install-claude.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Install this repo's plugins into a throwaway Claude Code config and assert
+# that the notte-browser skill and the anything.notte.cc MCP server are wired up.
+#
+# Runs in CI (.github/workflows/verify-install.yml) and locally:
+#
+#     scripts/verify-install-claude.sh [repo-root]
+#
+# Requires: claude (npm i -g @anthropic-ai/claude-code), jq.
+# No Anthropic credentials needed - every command used here is local-only.
+set -euo pipefail
+
+REPO_ROOT=${1:-$(git rev-parse --show-toplevel)}
+EXPECTED_SKILL=notte-browser
+EXPECTED_MCP_URL=https://anything.notte.cc/mcp
+
+# A fresh config dir per run, so a developer's own plugins can never make this pass.
+CLAUDE_CONFIG_DIR=$(mktemp -d)/claude
+export CLAUDE_CONFIG_DIR
+mkdir -p "$CLAUDE_CONFIG_DIR"
+trap 'rm -rf "$(dirname "$CLAUDE_CONFIG_DIR")"' EXIT
+
+fail() { echo "  FAIL  $*" >&2; exit 1; }
+ok() { echo "  ok    $*"; }
+
+echo "Claude Code $(claude --version)"
+echo "Installing from $REPO_ROOT into $CLAUDE_CONFIG_DIR"
+echo
+
+claude plugin marketplace add "$REPO_ROOT"
+claude plugin install notte@notte --scope user
+claude plugin install notte-migrate@notte --scope user
+echo
+
+installed=$(claude plugin list --json)
+
+for plugin in notte@notte notte-migrate@notte; do
+  jq -e --arg id "$plugin" 'any(.[]; .id == $id and .enabled == true)' >/dev/null <<<"$installed" \
+    || fail "$plugin is not installed and enabled"
+  ok "$plugin installed and enabled"
+done
+
+# The MCP server has to arrive through the plugin, not through a stray user config.
+jq -e --arg url "$EXPECTED_MCP_URL" \
+  'any(.[]; .id == "notte@notte" and (.mcpServers // {} | any(.[]; .url == $url)))' \
+  >/dev/null <<<"$installed" \
+  || fail "notte@notte does not contribute an MCP server at $EXPECTED_MCP_URL"
+ok "MCP server $EXPECTED_MCP_URL contributed by notte@notte"
+
+# `plugin details` is the inventory Claude Code actually loads a session from.
+details=$(claude plugin details notte@notte)
+grep -qE "^ *Skills \([0-9]+\).*\b${EXPECTED_SKILL}\b" <<<"$details" \
+  || { echo "$details" >&2; fail "'$EXPECTED_SKILL' is not listed as a skill of notte@notte"; }
+ok "skill $EXPECTED_SKILL listed in the notte@notte component inventory"
+
+grep -qE "^ *MCP servers \([0-9]+\)" <<<"$details" \
+  || { echo "$details" >&2; fail "notte@notte reports no MCP servers"; }
+ok "notte@notte reports MCP servers in its component inventory"
+
+# And the skill is really on disk in the installed copy, not just in the manifest.
+install_path=$(jq -er '.[] | select(.id == "notte@notte") | .installPath' <<<"$installed")
+[ -f "$install_path/skills/$EXPECTED_SKILL/SKILL.md" ] \
+  || fail "$install_path/skills/$EXPECTED_SKILL/SKILL.md is missing from the installed plugin"
+ok "SKILL.md present at $EXPECTED_SKILL in the installed plugin"
+
+echo
+echo "PASSED: Claude Code loads $EXPECTED_SKILL and $EXPECTED_MCP_URL."

--- a/scripts/verify-install-codex.sh
+++ b/scripts/verify-install-codex.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Install this repo's plugins into a throwaway Codex home and assert that the
+# notte-browser skill and the anything.notte.cc MCP server are wired up.
+#
+# Runs in CI (.github/workflows/verify-install.yml) and locally:
+#
+#     scripts/verify-install-codex.sh [repo-root]
+#
+# Requires: codex (npm i -g @openai/codex), jq, python3.
+# No OpenAI credentials needed - every command used here is local-only.
+set -euo pipefail
+
+REPO_ROOT=${1:-$(git rev-parse --show-toplevel)}
+EXPECTED_SKILL=notte-browser
+EXPECTED_MCP_URL=https://anything.notte.cc/mcp
+
+# A fresh CODEX_HOME per run, so a developer's own plugins can never make this pass.
+CODEX_HOME=$(mktemp -d)/codex
+export CODEX_HOME
+mkdir -p "$CODEX_HOME"
+trap 'rm -rf "$(dirname "$CODEX_HOME")"' EXIT
+
+fail() { echo "  FAIL  $*" >&2; exit 1; }
+ok() { echo "  ok    $*"; }
+
+echo "Codex $(codex --version)"
+echo "Installing from $REPO_ROOT into $CODEX_HOME"
+echo
+
+# Codex reads .claude-plugin/marketplace.json when a marketplace root has no
+# .codex-plugin equivalent, so the same manifests serve both clients.
+codex plugin marketplace add "$REPO_ROOT"
+notte_install=$(codex plugin add notte@notte --json)
+codex plugin add notte-migrate@notte --json >/dev/null
+echo
+
+installed=$(codex plugin list --json)
+
+for plugin in notte@notte notte-migrate@notte; do
+  jq -e --arg id "$plugin" \
+    'any(.installed[]; .pluginId == $id and .installed == true and .enabled == true)' \
+    >/dev/null <<<"$installed" \
+    || fail "$plugin is not installed and enabled"
+  ok "$plugin installed and enabled"
+done
+
+# `codex mcp list` reports the servers Codex would actually start, plugin-provided ones included.
+servers=$(codex mcp list --json)
+jq -e --arg url "$EXPECTED_MCP_URL" \
+  'any(.[]; .transport.url == $url and .enabled == true)' >/dev/null <<<"$servers" \
+  || { echo "$servers" >&2; fail "no enabled MCP server at $EXPECTED_MCP_URL"; }
+ok "MCP server $EXPECTED_MCP_URL enabled after install"
+
+# The installed copy - not the source tree - is what Codex loads skills from.
+install_path=$(jq -er '.installedPath' <<<"$notte_install")
+[ -f "$install_path/skills/$EXPECTED_SKILL/SKILL.md" ] \
+  || fail "$install_path/skills/$EXPECTED_SKILL/SKILL.md is missing from the installed plugin"
+ok "skill $EXPECTED_SKILL materialised at $install_path"
+
+# Everything above reads the CLI, which is a reduced projection: it drops the
+# `interface` metadata that the plugin browser and the ChatGPT app render. The
+# app-server API is where that surface lives, so check it too.
+echo
+python3 "$(dirname "$0")/verify-codex-app-server.py" "$REPO_ROOT"
+
+echo
+echo "PASSED: Codex loads $EXPECTED_SKILL and $EXPECTED_MCP_URL, and exposes its install-surface metadata."

--- a/scripts/verify-install-cursor.sh
+++ b/scripts/verify-install-cursor.sh
@@ -16,6 +16,11 @@
 #      session with the plugin loaded and asks it what it can see. This costs a
 #      few model tokens, so CI runs it on main and on a schedule, not per PR.
 #
+# Set CURSOR_REQUIRE_LIVE=1 to make a missing CURSOR_API_KEY a hard failure
+# rather than a skip. CI sets it on every run that is meant to include the live
+# probe, so an unset secret turns the job red instead of reporting a pass for a
+# check that never ran.
+#
 # Requires: jq. Live probe additionally requires cursor-agent and CURSOR_API_KEY.
 set -euo pipefail
 
@@ -74,9 +79,19 @@ jq -e --arg url "$EXPECTED_MCP_URL" 'any(.[]; .url == $url)' >/dev/null <<<"$ser
 ok "MCP server $EXPECTED_MCP_URL declared for Cursor"
 
 # --- live probe -------------------------------------------------------------
+# A missing key must not quietly downgrade this to a manifest check that still
+# reports success. Callers that expect the live probe set CURSOR_REQUIRE_LIVE=1
+# and get a hard failure instead; everyone else gets a loud skip notice.
 if [ -z "${CURSOR_API_KEY:-}" ]; then
+  if [ "${CURSOR_REQUIRE_LIVE:-}" = "1" ]; then
+    fail "CURSOR_REQUIRE_LIVE=1 but CURSOR_API_KEY is unset - refusing to report a pass for a check that did not run"
+  fi
   echo
-  echo "PASSED (manifest only): set CURSOR_API_KEY to also run the live cursor-agent probe."
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "::warning title=Cursor live probe skipped::No CURSOR_API_KEY, so only manifest resolution was checked. Nothing verified that Cursor loads the skill or MCP server."
+  fi
+  echo "SKIPPED the live probe: no CURSOR_API_KEY, so only the manifest was resolved."
+  echo "PASSED (manifest only) - this did NOT verify that Cursor loads anything."
   exit 0
 fi
 

--- a/scripts/verify-install-cursor.sh
+++ b/scripts/verify-install-cursor.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Verify that Cursor loads the notte-browser skill and the anything.notte.cc MCP server.
+#
+# Runs in CI (.github/workflows/verify-install.yml) and locally:
+#
+#     scripts/verify-install-cursor.sh [repo-root]
+#
+# Two modes, because the Cursor CLI has no offline "install and inspect" surface:
+#
+#   1. Manifest resolution (always). Resolves .cursor-plugin/plugin.json the way
+#      cursor-agent does and asserts the skill and MCP server it would expose.
+#      Cursor falls back to .claude-plugin/{marketplace,plugin}.json, which the
+#      Claude Code and Codex jobs already install for real - this covers the
+#      Cursor-specific root manifest, which is the one that drifts.
+#   2. Live probe (only when CURSOR_API_KEY is set). Boots a real cursor-agent
+#      session with the plugin loaded and asks it what it can see. This costs a
+#      few model tokens, so CI runs it on main and on a schedule, not per PR.
+#
+# Requires: jq. Live probe additionally requires cursor-agent and CURSOR_API_KEY.
+set -euo pipefail
+
+REPO_ROOT=${1:-$(git rev-parse --show-toplevel)}
+MANIFEST="$REPO_ROOT/.cursor-plugin/plugin.json"
+EXPECTED_SKILL=notte-browser
+EXPECTED_MCP_URL=https://anything.notte.cc/mcp
+
+fail() { echo "  FAIL  $*" >&2; exit 1; }
+ok() { echo "  ok    $*"; }
+
+# Strip a leading "./" and resolve against the plugin root, which for the Cursor
+# manifest is the repository root.
+resolve() { local p=${1#./}; echo "$REPO_ROOT/${p%/}"; }
+
+echo "Resolving $MANIFEST"
+[ -f "$MANIFEST" ] || fail ".cursor-plugin/plugin.json is missing"
+manifest=$(jq -e . "$MANIFEST") || fail ".cursor-plugin/plugin.json is not valid JSON"
+
+# --- skills -----------------------------------------------------------------
+# `skills` is a path or a list of paths, each pointing at a directory of skills.
+skill_roots=$(jq -r '.skills // empty | if type == "array" then .[] else . end' <<<"$manifest")
+[ -n "$skill_roots" ] || fail ".cursor-plugin/plugin.json declares no skills"
+
+found_skill=""
+while IFS= read -r root; do
+  candidate="$(resolve "$root")/$EXPECTED_SKILL/SKILL.md"
+  [ -f "$candidate" ] && found_skill=$candidate
+done <<<"$skill_roots"
+[ -n "$found_skill" ] \
+  || fail "no skills root in .cursor-plugin/plugin.json contains $EXPECTED_SKILL/SKILL.md"
+ok "skill $EXPECTED_SKILL resolves to ${found_skill#"$REPO_ROOT"/}"
+
+# --- mcpServers -------------------------------------------------------------
+# `mcpServers` is either a path to an .mcp.json or an inline server map.
+mcp_field=$(jq -r 'if has("mcpServers") then (.mcpServers | type) else "missing" end' <<<"$manifest")
+case "$mcp_field" in
+  missing)
+    fail ".cursor-plugin/plugin.json has no mcpServers - Cursor would load the skills but no MCP server"
+    ;;
+  string)
+    mcp_path=$(resolve "$(jq -r '.mcpServers' <<<"$manifest")")
+    [ -f "$mcp_path" ] || fail "mcpServers points at $mcp_path, which does not exist"
+    servers=$(jq -e '.mcpServers' "$mcp_path") || fail "$mcp_path has no mcpServers object"
+    ;;
+  object)
+    servers=$(jq -e '.mcpServers' <<<"$manifest")
+    ;;
+  *)
+    fail "mcpServers must be a path or an object, got $mcp_field"
+    ;;
+esac
+
+jq -e --arg url "$EXPECTED_MCP_URL" 'any(.[]; .url == $url)' >/dev/null <<<"$servers" \
+  || { echo "$servers" >&2; fail "no MCP server declared at $EXPECTED_MCP_URL"; }
+ok "MCP server $EXPECTED_MCP_URL declared for Cursor"
+
+# --- live probe -------------------------------------------------------------
+if [ -z "${CURSOR_API_KEY:-}" ]; then
+  echo
+  echo "PASSED (manifest only): set CURSOR_API_KEY to also run the live cursor-agent probe."
+  exit 0
+fi
+
+echo
+echo "Probing a live cursor-agent session with --plugin-dir $REPO_ROOT"
+probe=$(cd "$(mktemp -d)" && cursor-agent \
+  --plugin-dir "$REPO_ROOT" \
+  --mode ask \
+  --trust \
+  --approve-mcps \
+  --output-format text \
+  -p "List every skill name and every MCP server name available to you, one per line, nothing else.")
+
+grep -q "$EXPECTED_SKILL" <<<"$probe" \
+  || { echo "$probe" >&2; fail "live cursor-agent session does not see the $EXPECTED_SKILL skill"; }
+ok "live session sees the $EXPECTED_SKILL skill"
+
+# Cursor namespaces plugin MCP servers as plugin-<Plugin>-<server>, so match on the server name.
+grep -qE 'anything-api' <<<"$probe" \
+  || { echo "$probe" >&2; fail "live cursor-agent session does not see the anything-api MCP server"; }
+ok "live session sees the anything-api MCP server ($EXPECTED_MCP_URL)"
+
+echo
+echo "PASSED: Cursor loads $EXPECTED_SKILL and $EXPECTED_MCP_URL."


### PR DESCRIPTION
## Why

`validate-plugins.py` checks our manifests are well formed. Nothing checks that the clients agree with our reading of them — which is the only property that actually matters here. Every real failure so far has been a manifest that validated cleanly and still didn't wire up: the Cursor manifest declared `skills` and `rules` but no `mcpServers`, and three of four skills shipped without `agents/openai.yaml`. Both passed validation.

This installs the plugins with the real client CLIs and asserts what actually loads.

## What it checks

| Client | Surface | Credentials |
|---|---|---|
| Claude Code | `plugin marketplace add <checkout>` → `plugin install` → asserts both plugins enabled, `anything.notte.cc/mcp` contributed by `notte@notte`, `notte-browser` in the component inventory | none |
| Codex | same via `codex plugin add`, asserts `codex mcp list --json` reports the endpoint enabled — **plus** the app-server JSON-RPC API | none |
| Cursor | resolves the root manifest the way `cursor-agent` does; live agent probe on non-PR runs | live probe only |

Claude Code and Codex install **from the checkout**, so a PR is verified before it lands rather than after.

### Why Codex gets a second surface

`codex plugin list --json` is a reduced projection — it omits `interface` entirely. The `/plugins` browser and the ChatGPT desktop app read the app-server API instead, where marketplaces, plugins, and individual skills each carry their own `interface` block. So everything #26 added is invisible to the CLI, and asserting on the CLI alone would let all of it regress silently — which is exactly how three of four skills once shipped bare.

`scripts/verify-codex-app-server.py` drives `initialize` → `plugin/list` → `skills/list`. The expected skill inventory is derived from `plugins/*/skills/*/SKILL.md` **on disk**, not from the API response, so a skill that fails to load is caught rather than ignored.

Confirmed against seeded regressions:

```
$ rm plugins/notte/skills/notte-browser/agents/openai.yaml
  FAIL  skill notte:notte-browser has no interface metadata (Codex would render it bare)

$ # strip `interface` from plugins/notte/.codex-plugin/plugin.json
  FAIL  notte@notte interface is missing displayName, shortDescription

$ # install only the notte plugin, so one shipped skill is absent
  FAIL  app-server does not expose skill notte-migrate:migrate-to-notte, which this repo ships
```

## ⚠️ This needs a `CURSOR_API_KEY` secret before merge

The Cursor job **fails on main, cron, and manual dispatch if the secret is missing**. That is deliberate. An earlier revision degraded to a manifest-only check and still reported green, which is worse than having no check — a passing tick that means "we didn't test" is exactly what erodes trust in CI.

```bash
gh secret set CURSOR_API_KEY --repo nottelabs/notte-skills
```

On pull requests the live probe is skipped by design (it costs model tokens and asserts on model output). That skip is now visible rather than implied: it's a separate step that shows as skipped, and the log carries a warning annotation stating that nothing verified Cursor loads anything.

## The weekly cron matters as much as the PR runs

The jobs install the client CLIs at `@latest`. Codex reaching our plugins through the `.claude-plugin` / `.cursor-plugin` fallbacks is undocumented behaviour we don't control, and today nothing would tell us if it stopped — the failure mode is silent, where installs quietly stop wiring up and we hear about it from a user.

## Supply chain

`cursor-agent` is installed from a **version-pinned, sha256-verified** artifact rather than `curl https://cursor.com/install | bash`, because the following step hands that binary a real API key. Both `ludeeus/action-shellcheck` usages are pinned to a commit SHA rather than the mutable `@master`.

Trade-off worth naming: the pinned Cursor version needs manual bumping, since Dependabot doesn't watch a URL in a `run:` block.

## Local use

Each script stands alone and uses a throwaway config dir, so your own plugins can't make it pass:

```bash
scripts/verify-install-claude.sh
scripts/verify-install-codex.sh
scripts/verify-install-cursor.sh          # add CURSOR_API_KEY for the live probe
```

## Also

- shellcheck now scans `scripts/` (clean at `style`, stricter than the `warning` gate), and `lint-scripts` triggers when a shell script under `scripts/` changes — it previously only watched `scripts/*.py`.

## Unrelated, noticed while rebasing

`scripts/__pycache__/validate-plugins.cpython-314.pyc` is committed on `main`. Left alone here to keep this diff focused, but worth a `.gitignore` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
