### PR TITLE
Document file upload and download (two stores, two round trips)

### DIFF
--- a/plugins/notte/CHANGELOG.md
+++ b/plugins/notte/CHANGELOG.md
@@ -62,6 +62,29 @@ from the default branch will need the new invocation.
 
 ### Bug Fixes
 
+* **document file upload and download properly - the previous four lines were
+  misleading.** The browser is remote, so files do not cross between it and the
+  caller's machine on their own, and there are two separate stores selected with
+  `--from`: `uploads` (your account's library) and `session` (what this session's
+  browser downloaded). None of that was written down. Verified the round trips:
+  - `notte page upload --file <path>` resolves against the **uploads store, not
+    your filesystem**. The skill's `--file /path/to/file` example fails outright
+    with `Unable to get file: <path> for upload` unless that file was first sent
+    with `notte files upload`. Confirmed by watching the error disappear after
+    uploading the same file, then completing a real form upload end to end
+  - `notte page download` only moves a file as far as the **remote session**.
+    Retrieving it needs `notte files download <name> --from session --path <local>`,
+    a step that appeared nowhere. Confirmed a file is absent locally after
+    `page download` and present after `files download`
+  - `--use-file-storage` is **not** required for either: downloads landed in the
+    session store without it. The flag description and a
+    "Needed here for the PDF download" comment in function-management.md both
+    implied otherwise; the CLI claim is corrected and the SDK one is marked
+    untested rather than restated
+  - using an element id (`L3`) without a prior `notte page observe` in that
+    session fails with `No snapshot is available in the session`; CSS selectors
+    need no observe
+
 * **the marketplace check ran before there was anything to search for.** It sat
   in `notte-functions-build` Phase 0, ahead of the phase that works out the
   target site and fields. Moved to Phase 1c, after intent is parsed and before

--- a/plugins/notte/skills/notte-browser/SKILL.md
+++ b/plugins/notte/skills/notte-browser/SKILL.md
@@ -127,7 +127,8 @@ notte sessions start [flags]
                              explicit --viewport-width/--viewport-height
   --user-agent               Custom user agent string
   --cdp-url                  CDP URL of remote session provider
-  --use-file-storage         Enable file storage for the session
+  --use-file-storage         Attach FileStorage to the session (not needed just
+                             to download files - see Files below)
   --screenshot-type <type>   raw, full, or last_action
   --chrome-args              Override the Chrome instance arguments (repeatable)
   --extra-http-headers       Extra HTTP headers as JSON
@@ -254,11 +255,13 @@ notte page check "#my-checkbox"
 # Select dropdown option
 notte page select "#dropdown-element" "Option 1"
 
-# Download file by clicking element
+# Download a file by clicking an element. The file lands in the REMOTE session,
+# not on your machine - see "Files: upload and download" below.
 notte page download "L5"
 
-# Upload file to input
-notte page upload "#file-input" --file /path/to/file
+# Fill a file input. --file names a file already in your Notte uploads store,
+# NOT a path on your machine - see below.
+notte page upload "#file-input" --file report.pdf
 ```
 
 **Run JavaScript in the page:**
@@ -552,6 +555,44 @@ notte vaults credentials get --vault-id <vault-id> --url "https://site.com"
 notte vaults credentials delete --vault-id <vault-id> --url "https://site.com"
 ```
 
+### Files: upload and download
+
+The browser runs **remotely**, so files do not move between it and your machine on their own. There are two separate stores, selected with `--from`:
+
+| Store | Holds | Populated by |
+|-------|-------|--------------|
+| `uploads` | your account's file library, available to any session | `notte files upload <local-path>` |
+| `session` *(default)* | files this session's browser downloaded | `notte page download` |
+
+```bash
+notte files upload <local-path>          # local machine -> uploads store
+notte files list   [--from uploads|session] [--session-id <id>]
+notte files download <filename> [--from uploads|session] [--path <local-path>]
+```
+
+**Sending a local file into a web form** takes two steps. `notte page upload --file` resolves the name against the **uploads store**, not your filesystem - passing a local path that was never uploaded fails with `Unable to get file: <path> for upload`:
+
+```bash
+notte files upload ./invoice.pdf                      # 1. into the uploads store
+notte page upload "#file-input" --file invoice.pdf    # 2. into the page
+notte page click "#submit"
+```
+
+**Getting a downloaded file onto your machine** takes two steps as well - `page download` only moves it as far as the session:
+
+```bash
+notte page observe                                    # required before using an element ID
+notte page download "L3"                              # -> the session store, still remote
+notte files list --from session                       # confirm it arrived
+notte files download report.csv --from session --path ./report.csv
+```
+
+Notes:
+
+- `--use-file-storage` on `sessions start` is **not** required for this; downloads land in the session store either way.
+- The session store is per-session. Retrieve anything you need before the session ends, or pass `--session-id` to reach a specific one.
+- Using an element ID (`L3`, `B1`) without a prior `notte page observe` in that session fails with `No snapshot is available in the session`. A CSS selector needs no observe.
+
 ### Browser Profiles
 
 Profiles are the persistent browser state (cookies, `localStorage`, `sessionStorage`) that `--profile-id` loads. Create one before you can reference it:
@@ -600,7 +641,6 @@ notte search "what is anthropic" --output-type sourcedAnswer
 ### Other Commands
 
 ```bash
-notte files      # Manage uploaded files available to sessions
 notte usage      # Show API usage statistics
 notte health     # Check API health status
 notte clear      # Clear all stored CLI state (current session/agent/function pointers)

--- a/plugins/notte/skills/notte-browser/references/function-management.md
+++ b/plugins/notte/skills/notte-browser/references/function-management.md
@@ -567,7 +567,8 @@ vault = client.Vault("my-vault-id")
 
 def run(dashboard_url: str = "https://dashboard.example.com"):
     # `use_file_storage=True` attaches FileStorage - the same thing the
-    # `--use-file-storage` CLI flag does. Needed here for the PDF download.
+    # `--use-file-storage` CLI flag does. Note the CLI downloads files into the
+    # session store without it; whether the SDK path needs it here is untested.
     with client.Session(use_file_storage=True, vault=vault) as session:
         session.execute(type="goto", url=f"{dashboard_url}/login")
 

--- a/plugins/notte/skills/notte-browser/references/session-management.md
+++ b/plugins/notte/skills/notte-browser/references/session-management.md
@@ -57,7 +57,7 @@ notte sessions start \
   --viewport-width 1920 \         # Custom viewport
   --viewport-height 1080 \
   --user-agent "Custom UA" \      # Custom user agent
-  --use-file-storage              # Enable file storage for downloads
+  --use-file-storage              # Attach FileStorage (downloads work without it)
 ```
 
 See the main SKILL.md for the full flag list, including `--aspect-ratio`,


### PR DESCRIPTION
The skill covered files in four scattered lines, and two of them were wrong.

The browser runs **remotely**, so files do not cross between it and the caller's machine on their own — and there are two separate stores, selected with `--from`. None of that was written down.

| Store | Holds | Populated by |
|---|---|---|
| `uploads` | your account's file library | `notte files upload <local-path>` |
| `session` *(default)* | files this session's browser downloaded | `notte page download` |

## Three things verified against v0.0.30

**1. `page upload --file` reads the uploads store, not your filesystem.**

The documented example `notte page upload "#file-input" --file /path/to/file` **fails**:

```
Error: Unable to get file: /tmp/.../never_uploaded.txt for upload.
       Please check that it exists at the right path.
```

The file existed at that path locally — the CLI was never looking there. After `notte files upload`, the same command resolved and a real form upload completed end to end (`uploadSucceeded: true`). So it takes two steps:

```bash
notte files upload ./invoice.pdf                      # into the uploads store
notte page upload "#file-input" --file invoice.pdf    # into the page
```

**2. `page download` only reaches the remote session — the retrieval step was missing entirely.**

Confirmed the file is absent locally right after `page download` and present after `files download`:

```bash
notte page observe
notte page download "L3"                              # -> session store, still remote
notte files list --from session                       # confirm it arrived
notte files download report.csv --from session --path ./report.csv
```

The CLI already hints at this (`List downloaded files with: notte files list`); the docs ignored it.

**3. `--use-file-storage` is not required for either.** Downloads landed in the session store without it. The flag description said *"Enable file storage for downloads"* and `function-management.md` said *"Needed here for the PDF download"* — both implied a dependency that isn't there. The CLI claim is corrected; the SDK one is marked **untested** rather than restated, since only the CLI path was exercised.

Also noted: using an element id (`L3`) without a prior `notte page observe` in that session fails with `No snapshot is available in the session`. CSS selectors need no observe. Worth stating because the download example uses an id — I hit this myself while testing.

## Changes

- New **Files: upload and download** section in `notte-browser/SKILL.md` with the store table and both round trips
- Replaced the two misleading one-line examples
- Corrected the `--use-file-storage` description in `SKILL.md` and `session-management.md`
- Softened the unverified SDK claim in `function-management.md`
- Dropped the `notte files` one-liner from "Other Commands" now that it has a real section

## Verification

- `scripts/validate-plugins.py` — 37 checks, pass
- `scripts/test-validate-plugins.py` — 22 tests, pass
- Every command shown was run against v0.0.30 on a live session

## Note

There is no `notte files delete`, so the two probe files I uploaded while testing (`upload_probe.txt`, `never_uploaded.txt`) are still in the account's uploads store and cannot be removed from the CLI. Flagging in case that store is ever user-visible — and it may be worth a `files delete` subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)