### PR TITLE
Document the default-true session options, target CLI v0.0.31

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "notte",
   "displayName": "Notte",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Browser automation for AI agents — real cloud or local browsers, observe/click/fill/scrape primitives, structured Pydantic extraction from dynamic pages, captcha solving and stealth mode, authenticated sessions via Vault, and one-command deployment of any browser automation as a scheduled, API-callable Notte Function.",
   "author": {
     "name": "Notte",

--- a/plugins/notte/.claude-plugin/plugin.json
+++ b/plugins/notte/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notte",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Drive a real cloud or local browser with Notte \u2014 manage sessions and accounts from the CLI, and build, deploy, and repair Notte Functions",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/plugins/notte/.codex-plugin/plugin.json
+++ b/plugins/notte/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notte",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Drive a real cloud or local browser with Notte — manage sessions and accounts from the CLI, and build, deploy, and repair Notte Functions",
   "author": {
     "name": "Notte",

--- a/plugins/notte/CHANGELOG.md
+++ b/plugins/notte/CHANGELOG.md
@@ -12,6 +12,44 @@ not need a major bump - see <https://semver.org/#spec-item-4>. Tag releases as
 `notte-v<version>` from the first real release so consumers can pin instead of
 tracking the default branch.
 
+## 0.0.3 (2026-08-06)
+
+**Targets CLI v0.0.31 or newer.**
+
+Three session options default to `true` server-side - headless, captcha solving
+and file storage - which the skills documented as if they were opt-ins. v0.0.31
+adds a positive way to turn each off (nottelabs/notte-cli#61), so the docs now
+describe what is actually on and how to disable it, rather than telling an agent
+to enable things that are already enabled.
+
+### Features
+
+* document the real session lifetime: **3 minutes idle, 15 minutes total** by
+  default. Neither appeared anywhere, and they are short enough that a long
+  exploration, a slow login or a pause for user confirmation outlives them - at
+  which point the next command fails with a bare `Session closed`. Both
+  `notte-browser` and the session reference now state the defaults and show how
+  to raise them
+* `--headed` replaces `--headless=false` for a visible browser, `--no-solve-captchas`
+  and `--no-file-storage` replace the `=false` forms
+
+### Bug Fixes
+
+* **stop advising `--solve-captchas` on a blocked session.** `notte-functions-doctor`'s
+  anti-bot class and the exploration budget both suggested enabling it, but it
+  is on by default - the advice changed nothing while reading as a fix that had
+  been applied. They now point at `--proxy`/`--proxy-country` or an established
+  profile, which are the levers that remain
+* **correct the claim that a visible browser is unavailable remotely.**
+  `notte-browser` said `--headless=false` was for a local window and "not
+  available on remote/CI environments"; a cloud session accepts it and reports
+  `headless: false`. Watch it through the viewer URL
+* drop `--headless` from examples that only passed it to get the default
+  behaviour, and note that file storage and captcha solving need no flag either
+* the SDK notes and Cursor rules said file storage had to be switched on; it is
+  attached by default, and `use_file_storage=True` is now described as explicit
+  rather than required
+
 ## 0.0.2 (2026-08-06)
 
 First versioned state of the plugin, and the first entry after the version

--- a/plugins/notte/skills/notte-browser/SKILL.md
+++ b/plugins/notte/skills/notte-browser/SKILL.md
@@ -37,7 +37,7 @@ Both servers authenticate independently of `notte auth login`; a working CLI ses
 
 ## Setup
 
-Use this skill after the `notte` CLI is installed. **It assumes CLI v0.0.30 or newer** - that release renamed the list filter flags (`--include-deleted`, `-a`/`--all`, `--running`) and made `notte functions runs` return the full history by default. Check with `notte version` and upgrade if it is older; the commands below will not all work otherwise.
+Use this skill after the `notte` CLI is installed. **It assumes CLI v0.0.31 or newer.** v0.0.30 renamed the list filter flags (`--include-deleted`, `-a`/`--all`, `--running`) and made `notte functions runs` return the full history by default; v0.0.31 adds `--headed`, `--no-solve-captchas` and `--no-file-storage`. Check with `notte version` and upgrade if it is older; the commands below will not all work otherwise.
 
 If authentication is missing, run the interactive CLI login flow and wait for it to complete.
 
@@ -110,14 +110,16 @@ Control browser session lifecycle:
 ```bash
 # Start a new session
 notte sessions start [flags]
-  --headless                 Run in headless mode (default: true)
+  --headed                   Show a browser window. Headless is the default,
+                             so this is the flag you want, not --headless
+  --headless                 Force headless explicitly (already the default)
   --browser-type <type>      chromium (default) or chrome. chrome-nightly and
                              chrome-turbo are legacy aliases for chrome.
-  --idle-timeout-minutes     Idle timeout in minutes
-  --max-duration-minutes     Maximum session lifetime in minutes
+  --idle-timeout-minutes     Idle timeout in minutes (default: 3)
+  --max-duration-minutes     Maximum session lifetime in minutes (default: 15)
   --proxy                    Use default proxies
   --proxy-country <code>     Proxy country code (e.g. us, gb, fr). Implies --proxy
-  --solve-captchas           Automatically solve captchas
+  --no-solve-captchas        Turn OFF captcha solving (it is on by default)
   --vault-id <vault-id>      Attach a vault so sentinel placeholders resolve (see below)
   --profile-id <profile-id>  Load browser state from a profile
   --profile-persist          Save browser state back to the profile on session close
@@ -127,8 +129,9 @@ notte sessions start [flags]
                              explicit --viewport-width/--viewport-height
   --user-agent               Custom user agent string
   --cdp-url                  CDP URL of remote session provider
-  --use-file-storage         Attach FileStorage to the session (not needed just
-                             to download files - see Files below)
+  --no-file-storage          Detach FileStorage (it is attached by default).
+                             This disables `notte page download` and
+                             `notte files --from session`
   --screenshot-type <type>   raw, full, or last_action
   --chrome-args              Override the Chrome instance arguments (repeatable)
   --extra-http-headers       Extra HTTP headers as JSON
@@ -150,6 +153,16 @@ notte sessions stop
 # List sessions (with optional pagination and filters)
 notte sessions list [--page N] [--page-size N] [-a|--all]   # running only; -a includes stopped
 ```
+
+> **Sessions expire sooner than you might expect.** A session closes after
+> **3 minutes idle** or **15 minutes total**, whichever comes first. Long
+> exploration, a slow login, or a pause for user confirmation can all outlast
+> that, and the next command then fails with `Session closed` rather than
+> anything descriptive. Raise both when the task will not finish quickly:
+>
+> ```bash
+> notte sessions start --idle-timeout-minutes 15 --max-duration-minutes 60
+> ```
 
 **Note:** When you start a session, it automatically becomes the "current" session (i.e NOTTE_SESSION_ID environment variable is set). All subsequent commands use this session by default. Use `--session-id <session-id>` only when you need to manage multiple sessions simultaneously or reference a specific session.
 
@@ -589,7 +602,7 @@ notte files download report.csv --from session --path ./report.csv
 
 Notes:
 
-- `--use-file-storage` on `sessions start` is **not** required for this; downloads land in the session store either way.
+- **File storage is on by default**, so nothing extra is needed to download. Starting a session with `--no-file-storage` detaches it, after which `notte page download` fails with `Cannot execute download_file because no storage object was provided`.
 - The session store is per-session. Retrieve anything you need before the session ends, or pass `--session-id` to reach a specific one.
 - Using an element ID (`L3`, `B1`) without a prior `notte page observe` in that session fails with `No snapshot is available in the session`. A CSS selector needs no observe.
 
@@ -698,13 +711,13 @@ Session ID is resolved in this order:
 
 ```bash
 # Scrape with session
-notte sessions start --headless
+notte sessions start
 notte page goto "https://news.ycombinator.com"
 notte page scrape --instructions "Extract top 10 story titles"
 notte sessions stop
 
 # Multi-page scraping
-notte sessions start --headless
+notte sessions start
 notte page goto "https://example.com/products"
 notte page observe
 notte page scrape --instructions "Extract product names and prices"
@@ -760,7 +773,7 @@ notte sessions stop
 
 ```bash
 # 1. Build the workflow interactively, then export the session that worked
-notte sessions start --headless
+notte sessions start
 notte page goto "https://news.ycombinator.com"
 notte page scrape --instructions "Extract the top 10 stories with title, url, points"
 notte sessions workflow-code > collect_data.py
@@ -837,11 +850,11 @@ notte page click "#target-element"
 
 ### Viewing Headless Sessions
 
-Running with `--headless` (the default) doesn't mean you can't see the browser:
+Sessions are headless by default, which doesn't mean you can't see the browser:
 
 - **ViewerUrl**: When you start a session, the output includes a `ViewerUrl` - open it in your browser to watch the session live
 - **Viewer command**: `notte sessions viewer` opens the viewer directly
-- **Non-headless mode**: Use `--headless=false` only if you need a local browser window (not available on remote/CI environments)
+- **Headed mode**: `notte sessions start --headed` runs with a visible browser window. Cloud sessions accept this - watch it through the viewer URL rather than expecting a window on your own machine.
 
 ```bash
 # Start headless session and get viewer URL

--- a/plugins/notte/skills/notte-browser/references/function-management.md
+++ b/plugins/notte/skills/notte-browser/references/function-management.md
@@ -59,7 +59,7 @@ This example uses `scrape` to demonstrate the end-to-end CLI flow, not because i
 
 ```bash
 # Build your automation interactively and keep the session ID
-SESSION_ID=$(notte sessions start --headless -o json | jq -r '.session_id')
+SESSION_ID=$(notte sessions start -o json | jq -r '.session_id')
 notte page goto "https://news.ycombinator.com"
 notte page observe
 notte page scrape --instructions "Extract top 5 story titles and URLs"
@@ -580,9 +580,8 @@ vault = client.Vault("my-vault-id")
 
 
 def run(dashboard_url: str = "https://dashboard.example.com"):
-    # `use_file_storage=True` attaches FileStorage - the same thing the
-    # `--use-file-storage` CLI flag does. Note the CLI downloads files into the
-    # session store without it; whether the SDK path needs it here is untested.
+    # FileStorage is attached by default; passing use_file_storage=True here is
+    # explicit rather than required.
     with client.Session(use_file_storage=True, vault=vault) as session:
         session.execute(type="goto", url=f"{dashboard_url}/login")
 

--- a/plugins/notte/skills/notte-browser/references/python-sdk-interop.md
+++ b/plugins/notte/skills/notte-browser/references/python-sdk-interop.md
@@ -61,10 +61,10 @@ curl -L -X POST "https://api.notte.cc/functions/{function_id}/runs/start" \
 
 - Use `from notte_sdk import NotteClient` for hosted workflows. Do not mix it with local `import notte` examples in the same file.
 - Use `client.Session(...)` as a context manager.
-- Put `solve_captchas=True` and `proxies=True` on `Session`, not on `Agent`.
-- File storage is `client.Session(use_file_storage=True)` - matching the
-  `--use-file-storage` CLI flag. There is no `enable_file_storage` or `storage=`
-  keyword; those will raise a `TypeError`.
+- Put `solve_captchas=True` and `proxies=True` on `Session`, not on `Agent` - on `Agent` they are silently ignored. Captcha solving is already the server-side default, so `proxies=True` is the one that actually changes behaviour when a site blocks you.
+- File storage is `client.Session(use_file_storage=True)`, matching the CLI. It
+  is attached by default, so pass it only to be explicit. There is no
+  `enable_file_storage` or `storage=` keyword; those raise a `TypeError`.
 - Omit `from __future__ import annotations`. Under PEP 563 the Pydantic
   annotations become unresolved forward references and `response_format=Model`
   fails at runtime with `PydanticUserError: Model is not fully defined`.

--- a/plugins/notte/skills/notte-browser/references/session-management.md
+++ b/plugins/notte/skills/notte-browser/references/session-management.md
@@ -24,8 +24,8 @@ Complete guide to managing browser sessions with the notte CLI.
 # Start with defaults (headless chromium)
 notte sessions start
 
-# Start with visible browser
-notte sessions start --headless=false
+# Start with a visible browser
+notte sessions start --headed
 ```
 
 ### Browser Selection
@@ -45,19 +45,19 @@ are accepted as legacy aliases for `chrome`. There is no Firefox option.
 
 ```bash
 notte sessions start \
-  --headless=false \              # Show browser window
+  --headed \                      # Show a browser window (headless is default)
   --browser-type chromium \       # chromium or chrome
   --idle-timeout-minutes 10 \     # Close after 10 min of inactivity
   --max-duration-minutes 60 \     # Maximum 60 min session lifetime
   --proxy \                       # Use rotating proxies
-  --solve-captchas \              # Auto-solve CAPTCHAs
+  --no-solve-captchas \           # Turn OFF captcha solving (on by default)
   --vault-id <vault-id> \         # Attach a vault for sentinel credential fills
   --profile-id <profile-id> \     # Load browser state from a profile
   --profile-persist \             # Save browser state on session close
   --viewport-width 1920 \         # Custom viewport
   --viewport-height 1080 \
   --user-agent "Custom UA" \      # Custom user agent
-  --use-file-storage              # Attach FileStorage (downloads work without it)
+  --no-file-storage               # Detach FileStorage (attached by default)
 ```
 
 See the main SKILL.md for the full flag list, including `--aspect-ratio`,
@@ -208,9 +208,14 @@ notte page scrape --instructions "Extract:
 
 ## Session Timeouts
 
+Defaults are **3 minutes idle** and **15 minutes total** - short enough that a
+long exploration or a pause for user confirmation will hit them. When that
+happens the next command fails with `Session closed`, which does not say why, so
+raise them up front for anything slow.
+
 ### Idle Timeout
 
-Session closes after period of inactivity:
+Session closes after period of inactivity (default: 3 minutes):
 
 ```bash
 # Close after 10 minutes of no activity
@@ -221,7 +226,7 @@ Activity includes any command: observe, execute, scrape, etc.
 
 ### Max Duration
 
-Absolute maximum session lifetime:
+Absolute maximum session lifetime (default: 15 minutes):
 
 ```bash
 # Session closes after 60 minutes regardless of activity

--- a/plugins/notte/skills/notte-functions-build/SKILL.md
+++ b/plugins/notte/skills/notte-functions-build/SKILL.md
@@ -106,7 +106,7 @@ After the user confirms, run the rest without further questions unless something
 Start a session and develop the task interactively (this is exactly the `notte-browser` flow):
 
 ```bash
-notte sessions start --headless
+notte sessions start
 notte page goto "{url}"
 notte page observe
 notte page scrape --instructions "Extract {fields} as JSON" -o json

--- a/plugins/notte/skills/notte-functions-build/references/exploration.md
+++ b/plugins/notte/skills/notte-functions-build/references/exploration.md
@@ -22,7 +22,7 @@ A Function built on an internal API keeps working far longer than one built on C
 The data you see on the page almost always arrives via a background request. Find it:
 
 ```bash
-notte sessions start --headless
+notte sessions start
 notte page goto "{url}"
 # Trigger the data load: search, scroll, paginate, or click into a detail page
 notte page observe
@@ -109,7 +109,7 @@ Bake the pagination mechanism into a parameter (`max_pages`, `cursor`) so one Fu
 
 ## Exploration budget
 
-Cap exploration at roughly 100 tool steps. If you still cannot find a stable path - heavy bot protection, signed endpoints, a login wall you lack credentials for - stop and report the specific obstacle to the user with options (provide credentials, enable `--proxy`/`--solve-captchas`, accept a DOM-only path, pick a different source). Do not burn an unbounded number of steps.
+Cap exploration at roughly 100 tool steps. If you still cannot find a stable path - heavy bot protection, signed endpoints, a login wall you lack credentials for - stop and report the specific obstacle to the user with options (provide credentials, enable `--proxy`, accept a DOM-only path, pick a different source - captcha solving is already on by default, so it is not a lever you still have). Do not burn an unbounded number of steps.
 
 ## Success criteria
 

--- a/plugins/notte/skills/notte-functions-doctor/SKILL.md
+++ b/plugins/notte/skills/notte-functions-doctor/SKILL.md
@@ -29,7 +29,7 @@ Be honest about the boundary. Not every failure is a code fix, and flailing on a
 | Selector / endpoint drift (runs OK, returns empty/wrong shape) | **Fix** - re-explore, patch, verify, promote |
 | Hard exception in `run()` | **Fix** - re-explore the failing step, patch |
 | Expired credentials / auth wall | **Diagnose and report** - the user must refresh the vault/persona; not a code fix |
-| Anti-bot block / captcha | **Diagnose and advise** - suggest `--proxy` / `--solve-captchas`; do not blindly retry |
+| Anti-bot block / captcha | **Diagnose and advise** - suggest `--proxy` / a trusted profile; captcha solving is already on. Do not blindly retry |
 | Site genuinely gone or restructured | **Report** - confirm the new target/intent with the user before rebuilding |
 
 For the non-code-fixable classes, stop after diagnosis and tell the user the root cause and remedy. Do not edit code hoping it helps.
@@ -157,7 +157,7 @@ Decide: is this **code-fixable** (drift / exception) or **not** (auth / block / 
 For drift or an exception, find what changed by driving the **current** live site - exactly the exploration discipline `notte-functions-build` uses, but scoped to the step that broke:
 
 ```bash
-notte sessions start --headless
+notte sessions start
 notte page goto "{url from the function}"
 notte page observe
 notte page wait 1500

--- a/plugins/notte/skills/notte-functions-doctor/references/diagnosis.md
+++ b/plugins/notte/skills/notte-functions-doctor/references/diagnosis.md
@@ -50,7 +50,7 @@ notte functions run --function-id "{function_id}" -o json | jq '{status, result}
 
 **Meaning:** the site started challenging the session. The data path may be unchanged.
 
-**Action:** advise the session-level mitigations rather than touching extraction logic - `--proxy` / `--proxy-country`, `--solve-captchas`, or a profile with established trust. These are Function/session configuration. Do not loop retries blindly; that escalates the block.
+**Action:** advise the session-level mitigations rather than touching extraction logic - `--proxy` / `--proxy-country`, or a profile with established trust. **Do not suggest `--solve-captchas`: captcha solving is on by default**, so recommending it changes nothing and reads as a fix when none was applied. If a captcha is getting through anyway, the answer is a different IP or an established profile, not the flag. Do not loop retries blindly; that escalates the block.
 
 ### 5. Site gone or restructured  -  REPORT, then maybe rebuild
 

--- a/rules/notte-best-practices.mdc
+++ b/rules/notte-best-practices.mdc
@@ -7,11 +7,12 @@ alwaysApply: false
 - prefer `client.scrape(url=...)` over an agent when the task is "read this URL and give me X". Agents cost 5–10x more per run.
 - when the user wants structured output, define a Pydantic model and pass it as `response_format` to `agent.run` or `client.scrape`. Don't parse free-text answers.
 - script the deterministic parts with `session.execute(type=...)` and only hand the ambiguous step to the agent. This is Notte's biggest reliability + cost win.
-- enable `solve_captchas=True` and `proxies=True` on `Session` (not `Agent`) when scraping anti-bot sites. Putting them on `Agent` silently does nothing.
+- put `solve_captchas=True` and `proxies=True` on `Session`, never `Agent` — on `Agent` they silently do nothing. Captcha solving is already the default, so `proxies=True` is the one that changes anything when a site blocks you.
 - store credentials in `client.Vault()` — never paste them into the agent's `task` string. They will leak into logs.
 - `notte` (local) and `notte_sdk` (hosted) are two different imports, not aliases. Don't mix them in one file.
 - `reasoning_model` is a LiteLLM model string ("gemini/gemini-2.5-flash"), not a provider name, and must be one the platform advertises — run `notte agents start --help` for the current list rather than inventing one.
-- file storage on a session is `use_file_storage=True` (matching the `--use-file-storage` CLI flag). There is no `enable_file_storage` or `storage=` keyword.
+- file storage on a session is `use_file_storage=True` (matching the CLI) and is attached by default. There is no `enable_file_storage` or `storage=` keyword.
+- sessions close after 3 minutes idle or 15 minutes total by default. Raise `--idle-timeout-minutes`/`--max-duration-minutes` for anything slow, or the next command fails with an unexplained `Session closed`.
 - the trailing module-level `run()` call in a Function file is optional — the runtime invokes `run()` itself, so keeping or removing it makes no difference. `notte sessions workflow-code` emits one; leave it as-is.
 - never put `from __future__ import annotations` in a Function file — it breaks `response_format` with `PydanticUserError: Model is not fully defined`.
 - `notte functions run` blocks until the run finishes, so it is bounded by the global `--timeout` (default 60s). Raise it for slow Functions instead of assuming the Function is broken.


### PR DESCRIPTION
Three session options default to `true` server-side — **headless, captcha solving, file storage** — and the skills documented all three as if they were opt-ins. [notte-cli#61](https://github.com/nottelabs/notte-cli/pull/61) adds a positive way to turn each off, so this describes what's actually on and how to disable it.

Ships as **0.0.3**, targeting **CLI v0.0.31**.

> ⚠️ v0.0.31 isn't released yet. Merge this after it ships, or the `--headed` / `--no-*` flags won't exist for users. Setup states the required version with `notte version` as the check.

## The sweep found two things that weren't just wording

**1. Obsolete advice — telling agents to enable something already enabled.** `notte-functions-doctor`'s anti-bot failure class and `notte-functions-build`'s exploration budget both said to suggest `--solve-captchas` when a session gets blocked. It's on by default, so that recommendation changes nothing *while reading as a fix that was applied* — the worst kind of dead advice, because it terminates the diagnosis. Both now point at `--proxy` / `--proxy-country` or an established profile, which are the levers that actually remain.

**2. A wrong claim.** `notte-browser` said `--headless=false` was for a local window and *"not available on remote/CI environments"*. A cloud session accepts it and reports `headless: false` — you watch it through the viewer URL. Now documented as `--headed`.

## Newly documented: sessions expire in 3 / 15 minutes

Neither default appeared anywhere in the skills:

| | Default |
|---|---|
| Idle timeout | **3 minutes** |
| Max duration | **15 minutes** |

Both are short enough that a long exploration, a slow login, or a pause for user confirmation outlives them — and the next command then fails with a bare `Session closed` that doesn't say why. This surfaced while reading the OpenAPI defaults for notte-cli#60, and it's probably the highest-value line in this PR.

## Flag changes

| Was | Now |
|---|---|
| `--headless=false` | `--headed` |
| `--solve-captchas=false` | `--no-solve-captchas` |
| `--use-file-storage=false` | `--no-file-storage` |

`--headless` dropped from examples that only passed it to get the default behaviour. The SDK notes and Cursor rules no longer imply file storage must be switched on — it's attached by default, so `use_file_storage=True` is explicit rather than required.

## Files touched

Everything the sweep surfaced, across both plugins: `notte-browser/SKILL.md`, `session-management.md`, `function-management.md`, `python-sdk-interop.md`, `notte-functions-build/SKILL.md`, `exploration.md`, `notte-functions-doctor/SKILL.md`, `diagnosis.md`, and `rules/notte-best-practices.mdc`.

## Verification

- `scripts/validate-plugins.py` — 37 checks, pass
- `scripts/test-validate-plugins.py` — 22 tests, pass
- Shell templates pass `bash -n`
- Final grep confirms no remaining reference presents these as opt-ins

🤖 Generated with [Claude Code](https://claude.com/claude-code)